### PR TITLE
updating fillUIComponent methid after textarea attribute was removed

### DIFF
--- a/src/pages/Common/CommonItemsPage.ts
+++ b/src/pages/Common/CommonItemsPage.ts
@@ -141,16 +141,16 @@ export default class CommonItemsPage {
   async fillUIComponent<PageObject>(dataset: JSON, key: string, page: PageObject) {
     const locator: Locator = page[key];
     const typeAttribute = await locator.first().getAttribute('type');
-    if (typeAttribute === 'text' || typeAttribute === 'date' || typeAttribute === 'email' || typeAttribute === 'tel') {
-      await locator.fill(dataset[key]);
-    } else if (typeAttribute === 'radio') {
+    if (typeAttribute === 'radio') {
       await locator.locator('..').getByLabel(dataset[key], { exact: true }).check();
     } else if (typeAttribute === 'checkbox') {
       for (const checkbox of dataset[key]) {
         await locator.locator('..').getByLabel(checkbox, { exact: true }).check();
       }
-    } else {
+    } else if (confirmStringNotNull(await locator.getAttribute('class')).includes('govuk-select')) {
       await locator.selectOption({ label: dataset[key] });
+    } else {
+      await locator.fill(dataset[key]);
     }
   }
 

--- a/src/pages/IRAS/reviewResearch/userAdministration/manageUsers/CreateUserProfilePage.ts
+++ b/src/pages/IRAS/reviewResearch/userAdministration/manageUsers/CreateUserProfilePage.ts
@@ -20,7 +20,7 @@ export default class CreateUserProfilePage {
   readonly role_label: Locator;
   readonly role_fieldset: Locator;
   readonly role_checkbox: Locator;
-  readonly committee_dropdown_label: Locator;
+  readonly committee_dropdown: Locator;
   readonly country_fieldset: Locator;
   readonly country_checkbox: Locator;
   readonly access_required_fieldset: Locator;
@@ -83,7 +83,7 @@ export default class CreateUserProfilePage {
       .getByText(this.createUserProfilePageTestData.Create_User_Profile_Page.role_label, { exact: true });
     this.role_fieldset = this.page.locator('.govuk-form-group', { has: this.role_label });
     this.role_checkbox = this.role_fieldset.getByRole('checkbox');
-    this.committee_dropdown_label = this.page.getByLabel(
+    this.committee_dropdown = this.page.getByLabel(
       this.createUserProfilePageTestData.Create_User_Profile_Page.commitee_label,
       { exact: true }
     );


### PR DESCRIPTION
## What was the purpose of this ticket?

No ticket, quick fix to a common method after a code drop changed the attribute of the description textarea.

## Jira Ref

N/A

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New Tests
- [] Updating Tests
- [X] Fixing Tests
- [] Framework Improvements
- [] Documentation

## Solution

What work was completed to cover off the story?

- In CommonItemsPage fillUiComponent method
- Set the dropdown selection to be a conditional if statement
- Set the else statement to perform the basic locator.fill()
- This simplifies the logic as it will perform the basic fill unless its a radio, checkbox or dropdown element

## Checklist

Put [X] inside the [] to make the box ticked

- [X] Your code builds clean without any warnings, i.e. no ESLint or SonarCube errors
- [X] You have run the Pipeline jobs against this branch successfully
- [X] Any new or updated tests add value, i.e. provide correct assurances, fail when expected and log errors appropriately
- [] Tests have been tagged appropriately
- [X] No duplicate tests, steps or functions have been added
- [X] You are using the correct naming conventions
- [] Added files have been placed correctly within the projects folder structure
- [X] There is no dead code e.g. no "TODO" comments left, no unused imports etc
- [X] Any Framework updates have been explained and demonstrated to the team
