### PR TITLE
Adding BDD Hook to re-authenticate when auth states expire

### DIFF
--- a/src/hooks/CustomFixtures.ts
+++ b/src/hooks/CustomFixtures.ts
@@ -1,6 +1,6 @@
 import { test as base } from 'playwright-bdd';
 import AxeBuilder from '@axe-core/playwright';
-import { getAuthState, getTicketReferenceTags } from '../utils/UtilFunctions';
+import { getAuthState } from '../utils/UtilFunctions';
 import CommonItemsPage from '../pages/Common/CommonItemsPage';
 import LoginPage from '../pages/Common/LoginPage';
 import HomePage from '../pages/IRAS/HomePage';
@@ -297,15 +297,6 @@ export const test = base.extend<CustomFixtures>({
       channel = 'chrome';
     }
     await use(channel);
-  },
-
-  //Attach relevant ticket links to each scenario in test report
-  $beforeEach: async ({ $tags, $testInfo }, use) => {
-    const tickets = getTicketReferenceTags($tags);
-    if (tickets.length > 0) {
-      $testInfo.attach('Ticket Reference:', { body: tickets.toString().replace(/,/g, '') });
-    }
-    await use();
   },
 
   //Enable JavaScript in the BrowserContext for applicable, tagged scenarios

--- a/src/steps/Common/BddHooksSteps.ts
+++ b/src/steps/Common/BddHooksSteps.ts
@@ -1,0 +1,45 @@
+import { createBdd } from 'playwright-bdd';
+import { test } from '../../hooks/CustomFixtures';
+import { getTicketReferenceTags } from '../../utils/UtilFunctions';
+
+const { AfterStep, BeforeScenario } = createBdd(test);
+
+AfterStep(async ({ page, $step, $testInfo }) => {
+  if (
+    `${process.env.STEP_SCREENSHOT?.toLowerCase()}` === 'yes' ||
+    `${$step.title}` === 'I capture the page screenshot'
+  ) {
+    const screenshot = await page.screenshot({ path: 'screenshot.png', fullPage: true });
+    await $testInfo.attach(`[step] ${$step.title}`, { body: screenshot, contentType: 'image/png' });
+  }
+});
+
+BeforeScenario(
+  { name: 'Attach relevant ticket links to each scenario in test report' },
+  async function ({ $tags, $testInfo }) {
+    const tickets = getTicketReferenceTags($tags);
+    if (tickets.length > 0) {
+      $testInfo.attach('Ticket Reference:', { body: tickets.toString().replace(/,/g, '') });
+    }
+  }
+);
+
+BeforeScenario(
+  { name: 'Check that current auth state has not expired', tags: '@Regression or @SystemTest' },
+  async function ({ commonItemsPage, loginPage, homePage }) {
+    if (
+      (await commonItemsPage.page.request.get('application/welcome', { maxRedirects: 0 }).then((response) => {
+        return response.status();
+      })) != 200
+    ) {
+      console.info('Current auth states have expired!\nReauthenticating test users before continuing test execution');
+      await commonItemsPage.page.context().clearCookies();
+      await homePage.goto();
+      await homePage.loginBtn.click();
+      await loginPage.assertOnLoginPage();
+      await loginPage.loginWithUserCreds('Admin_User');
+      await homePage.assertOnHomePage();
+      await commonItemsPage.storeAuthState('Admin_User');
+    }
+  }
+);

--- a/src/steps/Common/CommonSteps.ts
+++ b/src/steps/Common/CommonSteps.ts
@@ -9,19 +9,9 @@ import {
   generateTestDataTelephone,
   writeGeneratedTestDataToJSON,
 } from '../../utils/GenerateTestData';
-const { Given, When, Then, AfterStep } = createBdd(test);
+const { Given, When, Then } = createBdd(test);
 import * as userProfileGeneratedataConfig from '../../resources/test_data/user_administration/testdata_generator/user_profile_generate_data_config.json';
 import { getCurrentTimeFormatted } from '../../utils/UtilFunctions';
-
-AfterStep(async ({ page, $step, $testInfo }) => {
-  if (
-    `${process.env.STEP_SCREENSHOT?.toLowerCase()}` === 'yes' ||
-    `${$step.title}` === 'I capture the page screenshot'
-  ) {
-    const screenshot = await page.screenshot({ path: 'screenshot.png', fullPage: true });
-    await $testInfo.attach(`[step] ${$step.title}`, { body: screenshot, contentType: 'image/png' });
-  }
-});
 
 Then('I capture the page screenshot', async () => {});
 


### PR DESCRIPTION
## What was the purpose of this ticket?

Adding before scenario hook to Regression and Sys Tests which checks auth states and refreshes them if required

## Jira Ref

N/A

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New Tests
- [] Updating Tests
- [X] Fixing Tests
- [X] Framework Improvements
- [] Documentation

## Solution

What work was completed to cover off the story?

- Added `BddHooksSteps` file
- Moved existing BDD hooks to this location 
- Removed existing BDD Hooks from current file locations
- Added BeforeScenario hook which checks if current auth states are valid via an API request, prior to running any test with the `@Regression` or `@SystemTest` tags associated with it
- If not valid then it will re-authenticate by re-using existing UI login functions
- Otherwise it will continue to use the existing auth states

## Checklist

Put [X] inside the [] to make the box ticked

- [X] Your code builds clean without any warnings, i.e. no ESLint or SonarCube errors
- [X] You have run the Pipeline jobs against this branch successfully
- [X] Any new or updated tests add value, i.e. provide correct assurances, fail when expected and log errors appropriately
- [X] Tests have been tagged appropriately
- [X] No duplicate tests, steps or functions have been added
- [X] You are using the correct naming conventions
- [X] Added files have been placed correctly within the projects folder structure
- [X] There is no dead code e.g. no "TODO" comments left, no unused imports etc
- [X] Any Framework updates have been explained and demonstrated to the team
