### PR TITLE
RSP - 1862 and 1865 - Relabel button and remove back link

### DIFF
--- a/src/pages/IRAS/makeChanges/KeyProjectRolesPage.ts
+++ b/src/pages/IRAS/makeChanges/KeyProjectRolesPage.ts
@@ -34,7 +34,7 @@ export default class KeyProjectRolesPage {
     this.chief_investigator_email_text = this.page.getByTestId('IQA0311_Text');
     this.sponsor_contact_email_text = this.page.getByTestId('IQA0313_Text');
     this.chief_investigator_email_text_summary_error_label = this.page.locator('a[href="#Questions[0].AnswerText"]');
-    this.sponsor_contact_email_text_summary_error_label = this.page.locator('a[href="#Questions[1].AnswerText"]');
+    this.sponsor_contact_email_text_summary_error_label = this.page.locator('a[href="#Questions[2].AnswerText"]');
     this.primary_sponsor_organisation_text = this.page.getByTestId('Questions_1_AnswerText');
     this.primary_sponsor_organisation_header_label = this.page.locator(
       'label[for="Questions_1_AnswerText_autocomplete"]'

--- a/src/pages/IRAS/makeChanges/KeyProjectRolesPage.ts
+++ b/src/pages/IRAS/makeChanges/KeyProjectRolesPage.ts
@@ -36,7 +36,9 @@ export default class KeyProjectRolesPage {
     this.chief_investigator_email_text_summary_error_label = this.page.locator('a[href="#Questions[0].AnswerText"]');
     this.sponsor_contact_email_text_summary_error_label = this.page.locator('a[href="#Questions[1].AnswerText"]');
     this.primary_sponsor_organisation_text = this.page.getByTestId('Questions_1_AnswerText');
-    this.primary_sponsor_organisation_header_label = this.page.locator('label[for="IQA0312_Text"]');
+    this.primary_sponsor_organisation_header_label = this.page.locator(
+      'label[for="Questions_1_AnswerText_autocomplete"]'
+    );
     this.primary_sponsor_organisation_jsenabled_text = this.page.getByRole('combobox', {
       name: keyProjectRolesPageTestData.Label_Texts.primary_sponsor_organisation_header_label,
     });

--- a/src/pages/IRAS/makeChanges/KeyProjectRolesPage.ts
+++ b/src/pages/IRAS/makeChanges/KeyProjectRolesPage.ts
@@ -35,7 +35,7 @@ export default class KeyProjectRolesPage {
     this.sponsor_contact_email_text = this.page.getByTestId('IQA0313_Text');
     this.chief_investigator_email_text_summary_error_label = this.page.locator('a[href="#Questions[0].AnswerText"]');
     this.sponsor_contact_email_text_summary_error_label = this.page.locator('a[href="#Questions[1].AnswerText"]');
-    this.primary_sponsor_organisation_text = this.page.getByTestId('IQA0312_Text');
+    this.primary_sponsor_organisation_text = this.page.getByTestId('Questions_1_AnswerText');
     this.primary_sponsor_organisation_header_label = this.page.locator('label[for="IQA0312_Text"]');
     this.primary_sponsor_organisation_jsenabled_text = this.page.getByRole('combobox', {
       name: keyProjectRolesPageTestData.Label_Texts.primary_sponsor_organisation_header_label,

--- a/src/pages/IRAS/makeChanges/MyResearchProjectsPage.ts
+++ b/src/pages/IRAS/makeChanges/MyResearchProjectsPage.ts
@@ -18,7 +18,9 @@ export default class MyResearchProjectsPage {
     this.pageHeading = this.page
       .getByRole('heading')
       .getByText(this.myResearchProjectsPageTestData.My_Research_Projects_Page.heading, { exact: true });
-    this.noProjectsAvailableLabel = this.page.locator('p[class="govuk-body"]').nth(0);
+    this.noProjectsAvailableLabel = this.page
+      .locator('p[class="govuk-body"]')
+      .getByText(this.myResearchProjectsPageTestData.Label_Texts.no_projects);
     this.btnCreateProjectRecord = this.page.getByRole('link', { name: 'Create project record' });
   }
 
@@ -30,5 +32,6 @@ export default class MyResearchProjectsPage {
   async assertOnMyResearchProjectsPage() {
     await expect(this.pageHeading).toBeVisible();
     await expect(this.btnCreateProjectRecord).toBeVisible();
+    await expect(this.noProjectsAvailableLabel).toBeVisible();
   }
 }

--- a/src/pages/IRAS/makeChanges/ProjectDetailsIRASPage.ts
+++ b/src/pages/IRAS/makeChanges/ProjectDetailsIRASPage.ts
@@ -17,7 +17,9 @@ export default class ProjectDetailsIRASPage {
     this.projectDetailsIRASPageTestData = projectDetailsIRASPageTestData;
 
     //Locators
-    this.pageHeading = this.page.getByRole('heading');
+    this.pageHeading = this.page
+      .getByRole('heading')
+      .getByText(this.projectDetailsIRASPageTestData.Project_Details_IRAS_Page.heading);
     this.iras_textbox_label = this.page.getByText(this.projectDetailsIRASPageTestData.Label_Texts.iras_textbox_label, {
       exact: true,
     });
@@ -31,7 +33,6 @@ export default class ProjectDetailsIRASPage {
   //Page Methods
   async assertOnProjectDetailsIRASPage() {
     await expect(this.pageHeading).toBeVisible();
-    await expect(this.pageHeading).toHaveText(this.projectDetailsIRASPageTestData.Project_Details_IRAS_Page.heading);
   }
 
   async setUniqueIrasId(value: string): Promise<void> {

--- a/src/pages/IRAS/makeChanges/ProjectDetailsIRASPage.ts
+++ b/src/pages/IRAS/makeChanges/ProjectDetailsIRASPage.ts
@@ -1,6 +1,5 @@
 import { expect, Locator, Page } from '@playwright/test';
 import * as projectDetailsIRASPageTestData from '../../../resources/test_data/iras/make_changes/project_details_iras_data.json';
-import * as fse from 'fs-extra';
 //Declare Page Objects
 export default class ProjectDetailsIRASPage {
   readonly page: Page;
@@ -41,17 +40,5 @@ export default class ProjectDetailsIRASPage {
 
   async getUniqueIrasId(): Promise<string> {
     return this._unique_iras_id;
-  }
-
-  async updateUniqueIrasIdTestDataJson(filePath: string, updateVal: string) {
-    (async () => {
-      try {
-        const data = await fse.readJson(filePath);
-        data.Invalid_IRAS_ID_Duplicate.iras_id_text = updateVal;
-        await fse.writeJson(filePath, data, { spaces: 2 });
-      } catch (error) {
-        throw new Error(`${error} Error updating unique iras id to testdata json file:`);
-      }
-    })();
   }
 }

--- a/src/pages/IRAS/makeChanges/ProjectDetailsTitlePage.ts
+++ b/src/pages/IRAS/makeChanges/ProjectDetailsTitlePage.ts
@@ -32,11 +32,11 @@ export default class ProjectDetailsTitlePage {
     this.short_project_title_textbox_label = this.page.locator('label[for="IQA0002_Text"]');
     this.provide_project_title_textbox_label = this.page.locator('#short-project-title-hint p');
     this.short_project_title_text = this.page.getByTestId('IQA0002_Text');
-    this.planned_end_date_textbox_label = this.page.locator('label[for="IQA0003_Text"]');
-    this.planned_end_date_hint_label = this.page.locator('#planned-project-end-date-hint p');
-    this.day_textbox_label = this.page.locator('label[for="Questions_1_Day"]');
-    this.month_textbox_label = this.page.locator('label[for="Questions_1_Month"]');
-    this.year_textbox_label = this.page.locator('label[for="Questions_1_Year"]');
+    this.planned_end_date_textbox_label = this.page.locator('label[for="Questions[1].AnswerText"]');
+    this.planned_end_date_hint_label = this.page.getByTestId('Questions[1]_AnswerText-hint').locator('p');
+    this.day_textbox_label = this.page.locator('label[for="Questions[1].Day"]');
+    this.month_textbox_label = this.page.locator('label[for="Questions[1].Month"]');
+    this.year_textbox_label = this.page.locator('label[for="Questions[1].Year"]');
     this.planned_project_end_day_text = this.page.getByTestId('Questions[1].Day');
     this.planned_project_end_month_text = this.page.getByTestId('Questions[1].Month');
     this.planned_project_end_year_text = this.page.getByTestId('Questions[1].Year');

--- a/src/pages/IRAS/makeChanges/ProjectDetailsTitlePage.ts
+++ b/src/pages/IRAS/makeChanges/ProjectDetailsTitlePage.ts
@@ -37,9 +37,9 @@ export default class ProjectDetailsTitlePage {
     this.day_textbox_label = this.page.locator('label[for="Questions_1_Day"]');
     this.month_textbox_label = this.page.locator('label[for="Questions_1_Month"]');
     this.year_textbox_label = this.page.locator('label[for="Questions_1_Year"]');
-    this.planned_project_end_day_text = this.page.getByTestId('Questions_1_Day');
-    this.planned_project_end_month_text = this.page.getByTestId('Questions_1_Month');
-    this.planned_project_end_year_text = this.page.getByTestId('Questions_1_Year');
+    this.planned_project_end_day_text = this.page.getByTestId('Questions[1].Day');
+    this.planned_project_end_month_text = this.page.getByTestId('Questions[1].Month');
+    this.planned_project_end_year_text = this.page.getByTestId('Questions[1].Year');
     this.short_project_title_text_summary_error_label = this.page.locator('a[href="#Questions[0].AnswerText"]');
     this.planned_project_end_day_text_summary_error_label =
       this.planned_project_end_month_text_summary_error_label =

--- a/src/pages/IRAS/makeChanges/ResearchLocationsPage.ts
+++ b/src/pages/IRAS/makeChanges/ResearchLocationsPage.ts
@@ -24,12 +24,11 @@ export default class ResearchLocationsPage {
     this.nations_participating_checkbox = this.page.locator('input[id^="Questions[0]"]:not([type="hidden"])');
     this.is_nhs_hsc_organisation_radio = this.page.getByTestId(/^IQA0004/);
     this.lead_nation_radio = this.page.getByTestId(/^IQA0005/);
-    this.nations_participating_label = this.page.locator('div[id="Questions[0].Answers"] govuk-fieldset-legend');
-    this.nations_participating_hint_label = this.page
-      .locator('div[id="Questions[0].Answers"] govuk-fieldset-legend')
+    this.nations_participating_label = this.page.getByTestId('Questions[0]_Answers').locator('govuk-fieldset-legend');
+    this.nations_participating_hint_label = this.nations_participating_label
       .locator('..')
       .locator('..')
-      .locator('div[id="rule-hint"]');
+      .getByTestId('Questions[0]_Answers-hint');
     this.is_nhs_hsc_organisation_label = this.page.locator(
       'div[id="Questions[1].SelectedOption"] govuk-fieldset-legend'
     );

--- a/src/pages/IRAS/makeChanges/ResearchLocationsPage.ts
+++ b/src/pages/IRAS/makeChanges/ResearchLocationsPage.ts
@@ -21,7 +21,7 @@ export default class ResearchLocationsPage {
 
     //Locators
     this.pageHeading = this.page.getByTestId('title');
-    this.nations_participating_checkbox = this.page.getByTestId(/^IQA0032/);
+    this.nations_participating_checkbox = this.page.locator('input[id^="Questions[0]"]:not([type="hidden"])');
     this.is_nhs_hsc_organisation_radio = this.page.getByTestId(/^IQA0004/);
     this.lead_nation_radio = this.page.getByTestId(/^IQA0005/);
     this.nations_participating_label = this.page.locator('div[id="Questions[0].Answers"] govuk-fieldset-legend');

--- a/src/resources/test_data/common/button_text_data.json
+++ b/src/resources/test_data/common/button_text_data.json
@@ -27,7 +27,7 @@
     "Start": "Start"
   },
   "Project_Details_IRAS_Page": {
-    "Save_Continue": "Save and continue"
+    "Add_Project": "Add project"
   },
   "Project_Details_Title_Page": {
     "Save_Continue": "Save and continue",

--- a/src/resources/test_data/common/link_text_data.json
+++ b/src/resources/test_data/common/link_text_data.json
@@ -110,7 +110,7 @@
   "Audit_History_User_Page": {
     "Back": "Back"
   },
-  "Project_Overview_Save_For_Later_Page": {
+  "Project_Overview_Page": {
     "Project_Details": "Project details"
   },
   "Review_Body_User_List_Page": {

--- a/src/resources/test_data/common/rts_page_data.json
+++ b/src/resources/test_data/common/rts_page_data.json
@@ -12,7 +12,7 @@
     "token_type": "Bearer"
   },
   "RTS_Active_Sponsor_Organisation_NHS": {
-    "rts_base_url": "https://test.fhir.rts.nihr.ac.uk/api/",
+    "rts_base_url": "https://oat.fhir.rts.nihr.ac.uk/api/",
     "content_type_json": "application/json",
     "organisation_name": "nhs",
     "active": true,
@@ -21,7 +21,7 @@
     "offset": "3000"
   },
   "RTS_Active_Sponsor_Organisation_MAN": {
-    "rts_base_url": "https://test.fhir.rts.nihr.ac.uk/api/",
+    "rts_base_url": "https://oat.fhir.rts.nihr.ac.uk/api/",
     "content_type_json": "application/json",
     "organisation_name": "man",
     "active": true,
@@ -30,7 +30,7 @@
     "offset": "3000"
   },
   "RTS_Active_Sponsor_Organisation_Brackets": {
-    "rts_base_url": "https://test.fhir.rts.nihr.ac.uk/api/",
+    "rts_base_url": "https://oat.fhir.rts.nihr.ac.uk/api/",
     "content_type_json": "application/json",
     "organisation_name": "(Sp",
     "active": true,
@@ -39,7 +39,7 @@
     "offset": "3000"
   },
   "RTS_Active_Sponsor_Organisation_Dot_Comma": {
-    "rts_base_url": "https://test.fhir.rts.nihr.ac.uk/api/",
+    "rts_base_url": "https://oat.fhir.rts.nihr.ac.uk/api/",
     "content_type_json": "application/json",
     "organisation_name": ".,L",
     "active": true,
@@ -48,7 +48,7 @@
     "offset": "3000"
   },
   "RTS_Active_Sponsor_Organisation_Slash": {
-    "rts_base_url": "https://test.fhir.rts.nihr.ac.uk/api/",
+    "rts_base_url": "https://oat.fhir.rts.nihr.ac.uk/api/",
     "content_type_json": "application/json",
     "organisation_name": "A/S",
     "active": true,
@@ -57,7 +57,7 @@
     "offset": "3000"
   },
   "RTS_Active_Sponsor_Organisation_Hyphen": {
-    "rts_base_url": "https://test.fhir.rts.nihr.ac.uk/api/",
+    "rts_base_url": "https://oat.fhir.rts.nihr.ac.uk/api/",
     "content_type_json": "application/json",
     "organisation_name": "e-T",
     "active": true,
@@ -66,7 +66,7 @@
     "offset": "3000"
   },
   "RTS_Active_Sponsor_Organisation_Start_Space": {
-    "rts_base_url": "https://test.fhir.rts.nihr.ac.uk/api/",
+    "rts_base_url": "https://oat.fhir.rts.nihr.ac.uk/api/",
     "content_type_json": "application/json",
     "organisation_name": " nh",
     "active": true,
@@ -75,7 +75,7 @@
     "offset": "3000"
   },
   "RTS_Active_Sponsor_Organisation_Ends_Space": {
-    "rts_base_url": "https://test.fhir.rts.nihr.ac.uk/api/",
+    "rts_base_url": "https://oat.fhir.rts.nihr.ac.uk/api/",
     "content_type_json": "application/json",
     "organisation_name": "hs ",
     "active": true,

--- a/src/resources/test_data/iras/make_changes/key_project_roles_data.json
+++ b/src/resources/test_data/iras/make_changes/key_project_roles_data.json
@@ -127,6 +127,7 @@
   },
   "Valid_Email_Data_Special_Characters": {
     "chief_investigator_email_text": "john!#$%&'*+-/=?^_`{|}~doe@example.com",
+    "primary_sponsor_organisation_text": "CHESTERFIELD ROYAL HOSPITAL NHS FOUNDATION TRUST",
     "sponsor_contact_email_text": "john!#$%&'*+-/=?^_`{|}~doe@example.com"
   },
   "Valid_Email_Data_Hyphen_Underscore": {

--- a/src/resources/test_data/iras/make_changes/project_details_iras_data.json
+++ b/src/resources/test_data/iras/make_changes/project_details_iras_data.json
@@ -33,9 +33,6 @@
   "Invalid_IRAS_ID_Min_Length": {
     "iras_id_text": "12"
   },
-  "Invalid_IRAS_ID_Max_Length": {
-    "iras_id_text": "123456789"
-  },
   "Invalid_IRAS_ID_Leading_Zeros": {
     "iras_id_text": "000123"
   },

--- a/src/resources/test_data/iras/make_changes/project_details_iras_data.json
+++ b/src/resources/test_data/iras/make_changes/project_details_iras_data.json
@@ -21,12 +21,6 @@
   "Field_Error_Message_Iras_Id_Leading_Zeros": {
     "iras_id_text": "IRAS ID cannot start with '0'"
   },
-  "Valid_IRAS_ID_Max": {
-    "iras_id_text": ""
-  },
-  "Valid_IRAS_ID_Min": {
-    "iras_id_text": ""
-  },
   "Invalid_IRAS_ID_Letters": {
     "iras_id_text": "abcdefg"
   },
@@ -59,8 +53,5 @@
   },
   "Invalid_IRAS_ID_Blank": {
     "iras_id_text": ""
-  },
-  "Invalid_IRAS_ID_Duplicate": {
-    "iras_id_text": "4609595"
   }
 }

--- a/src/resources/test_data/iras/make_changes/project_details_iras_data.json
+++ b/src/resources/test_data/iras/make_changes/project_details_iras_data.json
@@ -31,10 +31,10 @@
     "iras_id_text": "a!b£c£D%"
   },
   "Invalid_IRAS_ID_Min_Length": {
-    "iras_id_text": ""
+    "iras_id_text": "12"
   },
   "Invalid_IRAS_ID_Max_Length": {
-    "iras_id_text": ""
+    "iras_id_text": "123456789"
   },
   "Invalid_IRAS_ID_Leading_Zeros": {
     "iras_id_text": "000123"

--- a/src/steps/Common/CommonSteps.ts
+++ b/src/steps/Common/CommonSteps.ts
@@ -247,6 +247,11 @@ Given('I can see a {string} link on the {string}', async ({ commonItemsPage }, l
   }
 });
 
+Given('I cannot see a {string} link on the {string}', async ({ commonItemsPage }, linkKey: string, pageKey: string) => {
+  const linkValue = commonItemsPage.linkTextData[pageKey][linkKey];
+  await expect(commonItemsPage.govUkLink.getByText(linkValue, { exact: true })).toHaveCount(0);
+});
+
 Then(
   'I generate {string} test data for {string}',
   async ({ commonItemsPage }, typeofdata: string, fieldName: string) => {

--- a/src/steps/Common/RtsSteps.ts
+++ b/src/steps/Common/RtsSteps.ts
@@ -35,8 +35,16 @@ Then(
       const receivedJson = await requestResponse.json();
       if (typeof receivedJson.entry !== 'undefined') {
         receivedJson.entry.forEach((element) => {
-          if (element.resource.active === active) {
-            rtsPage.rtsResponseList.push(element.resource.name);
+          const organisationRoles = element.resource.extension;
+          for (const organisationRole of organisationRoles) {
+            if (typeof organisationRole.extension !== 'undefined') {
+              const extensions = organisationRole.extension;
+              if (extensions[0].valueString === role) {
+                if (extensions[3].valueString === 'Active' && element.resource.active === active) {
+                  rtsPage.rtsResponseList.push(element.resource.name);
+                }
+              }
+            }
           }
         });
       } else {

--- a/src/steps/IRAS/makeChanges/KeyProjectRolesSteps.ts
+++ b/src/steps/IRAS/makeChanges/KeyProjectRolesSteps.ts
@@ -144,7 +144,7 @@ Then(
     await keyProjectRolesPage.page.waitForTimeout(2000);
     const continueEnteringSuggestionActual = await keyProjectRolesPage.primary_sponsor_organisation_suggestion_listbox
       .first()
-      .getAttribute('data-before-suggestions');
+      .getAttribute('data-after-suggestions');
     const suggestionsHeaderLabelExpected = suggestionHeadersDatasetName.suggestion_footer;
     expect(continueEnteringSuggestionActual).toEqual(suggestionsHeaderLabelExpected);
   }

--- a/src/steps/IRAS/makeChanges/KeyProjectRolesSteps.ts
+++ b/src/steps/IRAS/makeChanges/KeyProjectRolesSteps.ts
@@ -1,6 +1,7 @@
 import { createBdd } from 'playwright-bdd';
 import { expect, test } from '../../../hooks/CustomFixtures';
 import { sortArray } from '../../../utils/UtilFunctions';
+import config from '../../../../playwright.config';
 
 const { Then } = createBdd(test);
 
@@ -14,7 +15,10 @@ Then(
     const dataset = keyProjectRolesPage.keyProjectRolesPageTestData[datasetName];
     for (const key in dataset) {
       if (Object.prototype.hasOwnProperty.call(dataset, key)) {
-        if (key === 'primary_sponsor_organisation_text' && $tags.includes('@jsEnabled')) {
+        if (
+          key === 'primary_sponsor_organisation_text' &&
+          ($tags.includes('@jsEnabled') || config.projects?.[1].use?.javaScriptEnabled)
+        ) {
           dataset['primary_sponsor_organisation_jsenabled_text'] = dataset['primary_sponsor_organisation_text'];
           await commonItemsPage.fillUIComponent(
             dataset,

--- a/src/steps/IRAS/makeChanges/MyResearchProjectsSteps.ts
+++ b/src/steps/IRAS/makeChanges/MyResearchProjectsSteps.ts
@@ -1,5 +1,5 @@
 import { createBdd } from 'playwright-bdd';
-import { expect, test } from '../../../hooks/CustomFixtures';
+import { test } from '../../../hooks/CustomFixtures';
 
 const { Then } = createBdd(test);
 
@@ -11,11 +11,3 @@ Then('I have navigated to the my research projects page', async ({ myResearchPro
 Then('I can see the my research projects page', async ({ myResearchProjectsPage }) => {
   await myResearchProjectsPage.assertOnMyResearchProjectsPage();
 });
-
-Then(
-  'I can see the {string} on the my research project page',
-  async ({ myResearchProjectsPage }, datasetName: string) => {
-    const dataset = myResearchProjectsPage.myResearchProjectsPageTestData[datasetName];
-    expect((await myResearchProjectsPage.noProjectsAvailableLabel.textContent())?.trim()).toBe(dataset.no_projects);
-  }
-);

--- a/src/steps/IRAS/makeChanges/ProjectDetailsIRASSteps.ts
+++ b/src/steps/IRAS/makeChanges/ProjectDetailsIRASSteps.ts
@@ -27,14 +27,7 @@ Then(
     const dataset = projectDetailsIRASPage.projectDetailsIRASPageTestData[datasetName];
     for (const key in dataset) {
       if (Object.prototype.hasOwnProperty.call(dataset, key)) {
-        if (
-          [
-            'Valid_IRAS_ID_Max',
-            'Valid_IRAS_ID_Min',
-            'Invalid_IRAS_ID_Min_Length',
-            'Invalid_IRAS_ID_Max_Length',
-          ].includes(datasetName)
-        ) {
+        if (['Valid_IRAS_ID_Max', 'Valid_IRAS_ID_Min', 'Invalid_IRAS_ID_Min_Length'].includes(datasetName)) {
           dataset[key] = generateIrasId(datasetName);
         }
         await commonItemsPage.fillUIComponent(dataset, key, projectDetailsIRASPage);

--- a/src/steps/IRAS/makeChanges/ProjectDetailsIRASSteps.ts
+++ b/src/steps/IRAS/makeChanges/ProjectDetailsIRASSteps.ts
@@ -1,8 +1,6 @@
 import { createBdd } from 'playwright-bdd';
 import { expect, test } from '../../../hooks/CustomFixtures';
 import { generateIrasId, generateRandomValidIrasId } from '../.././../utils/GenerateTestData';
-import path from 'path';
-const pathToTestDataJson = './src/resources/test_data/iras/make_changes/project_details_iras_data.json';
 
 const { Then } = createBdd(test);
 
@@ -48,9 +46,7 @@ Then(
 Then('I fill the unique iras id in project details iras page', async ({ projectDetailsIRASPage }) => {
   const uniqueIrasId = generateRandomValidIrasId();
   await projectDetailsIRASPage.setUniqueIrasId(uniqueIrasId);
-  const filePath = path.resolve(pathToTestDataJson);
-  await projectDetailsIRASPage.updateUniqueIrasIdTestDataJson(filePath, uniqueIrasId);
-  await projectDetailsIRASPage.iras_id_text.fill(uniqueIrasId);
+  await projectDetailsIRASPage.iras_id_text.fill(await projectDetailsIRASPage.getUniqueIrasId());
 });
 
 Then('I fill the existing iras id in project details iras page', async ({ projectDetailsIRASPage }) => {

--- a/src/utils/GenerateTestData.ts
+++ b/src/utils/GenerateTestData.ts
@@ -728,10 +728,6 @@ export function generateIrasId(irasIdType: string): string {
       //Generates invalid random IRAS ID with a digit lenght 2
       irasId = generateRandomNumber(2, 2);
       break;
-    case 'Invalid_IRAS_ID_Max_Length':
-      //Generates invalid random IRAS ID with a digit lenght 9
-      irasId = generateRandomNumber(9, 9);
-      break;
     default:
       throw new Error(`Unknown IRAS ID Type: ${irasIdType}`);
   }

--- a/src/utils/GenerateTestData.ts
+++ b/src/utils/GenerateTestData.ts
@@ -725,12 +725,12 @@ export function generateIrasId(irasIdType: string): string {
       irasId = generateRandomNumber(4, 4);
       break;
     case 'Invalid_IRAS_ID_Min_Length':
-      //Generates invalid random IRAS ID with a digit lenght 8
-      irasId = generateRandomNumber(8, 8);
+      //Generates invalid random IRAS ID with a digit lenght 2
+      irasId = generateRandomNumber(2, 2);
       break;
     case 'Invalid_IRAS_ID_Max_Length':
-      //Generates invalid random IRAS ID with a digit lenght 3
-      irasId = generateRandomNumber(3, 3);
+      //Generates invalid random IRAS ID with a digit lenght 9
+      irasId = generateRandomNumber(9, 9);
       break;
     default:
       throw new Error(`Unknown IRAS ID Type: ${irasIdType}`);

--- a/tests/features/cross-compatible/accessibility/AxeAccessibility.feature
+++ b/tests/features/cross-compatible/accessibility/AxeAccessibility.feature
@@ -39,8 +39,8 @@ Feature: Run Axe Accessibilty Test Tool Against App Pages
     Given I have navigated to the my research projects page
     And I click the 'Create_Project_Record' button on the 'My_Research_Projects_Page'
     When I click the 'Start' button on the 'Create_Project_Record_Page'
-    And I fill the project details iras page with 'Valid_IRAS_ID_Max'
-    When I click the 'Save_Continue' button on the 'Project_Details_IRAS_Page'
+    And I fill the unique iras id in project details iras page
+    When I click the 'Add_Project' button on the 'Project_Details_IRAS_Page'
     Then I can see the project details title page
     When I Scan the page with the Axe Accessibilty Tool
     And I analyse the results from the Axe scan

--- a/tests/features/cross-compatible/stories/regressionTests/CreateProject.feature
+++ b/tests/features/cross-compatible/stories/regressionTests/CreateProject.feature
@@ -7,9 +7,8 @@ Feature: Create Amendment - Create Project - Regression Tests
 
   @CreateProjectValidRegression
   Scenario Outline: Validate user is able to amend a project
-    And I can see the my research projects page
     # Validate labels in My_Research_Projects_Page
-    And I can see the '<Validation_Text>' on the my research project page
+    And I can see the my research projects page
     And I capture the page screenshot
     When I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     Then I can see the create project record page
@@ -27,7 +26,7 @@ Feature: Create Amendment - Create Project - Regression Tests
     And I capture the page screenshot
     And I fill the unique iras id in project details iras page
     And I capture the page screenshot
-    When I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    When I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     Then I can see the project details title page
     And I capture the page screenshot
     # Validate labels in Project_Details_Title_Page
@@ -79,62 +78,62 @@ Feature: Create Amendment - Create Project - Regression Tests
     And I capture the page screenshot
 
     Examples:
-      | Validation_Text | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Third | Navigation_Link | Project_Details_Title      | Key_Project_Roles                   | Research_Locations                     |
-      | Label_Texts     | Create_Project_Record   | Start                    | Save_Continue           | Back            | Valid_Data_All_Fields      | Valid_Data_All_Fields               | Data_With_No_NHS_HSC                   |
-      | Label_Texts     | Create_Project_Record   | Start                    | Save_Continue          | Back  | Valid_Data_All_Fields_VERA | Valid_Email_Data_Special_Characters | Data_With_Lead_Nation_Northern_Ireland |
-  
+      | Validation_Text | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Third | Navigation_Button_Add_Project | Navigation_Link | Project_Details_Title      | Key_Project_Roles                   | Research_Locations                     |
+      | Label_Texts     | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Back            | Valid_Data_All_Fields      | Valid_Data_All_Fields               | Data_With_No_NHS_HSC                   |
+      | Label_Texts     | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Back            | Valid_Data_All_Fields_VERA | Valid_Email_Data_Special_Characters | Data_With_Lead_Nation_Northern_Ireland |
+
   @ErrorMessageInvalidIRASIDRegression
   Scenario Outline: Validate error messages displayed when user amend the project using invalid iras id
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the project details iras page with '<Project_Details_IRAS>'
-    When I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    When I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     Then I validate '<Field_And_Summary_Error_Message>' displayed on 'Project_Details_IRAS_Page'
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS             | Navigation_Button_Third | Field_And_Summary_Error_Message       |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Letters          | Save_Continue           | Field_Error_Message                   |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Symbols          | Save_Continue           | Field_Error_Message                   |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Letters_Symbols  | Save_Continue           | Field_Error_Message                   |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Min_Length       | Save_Continue           | Field_Error_Message_Iras_Id_Length    |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces           | Save_Continue           | Field_Error_Message_Iras_Id_Mandatory |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces_Suffix    | Save_Continue           | Field_Error_Message                   |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces_Prefix    | Save_Continue           | Field_Error_Message                   |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces_Seperator | Save_Continue           | Field_Error_Message                   |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Blank            | Save_Continue           | Field_Error_Message_Iras_Id_Mandatory |
+      | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS             | Navigation_Button_Third | Navigation_Button_Add_Project | Field_And_Summary_Error_Message       |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Letters          | Save_Continue           | Add_Project                   | Field_Error_Message                   |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Symbols          | Save_Continue           | Add_Project                   | Field_Error_Message                   |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Letters_Symbols  | Save_Continue           | Add_Project                   | Field_Error_Message                   |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Min_Length       | Save_Continue           | Add_Project                   | Field_Error_Message_Iras_Id_Length    |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces           | Save_Continue           | Add_Project                   | Field_Error_Message_Iras_Id_Mandatory |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces_Suffix    | Save_Continue           | Add_Project                   | Field_Error_Message                   |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces_Prefix    | Save_Continue           | Add_Project                   | Field_Error_Message                   |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces_Seperator | Save_Continue           | Add_Project                   | Field_Error_Message                   |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Blank            | Save_Continue           | Add_Project                   | Field_Error_Message_Iras_Id_Mandatory |
 
   @ErrorMessageInvalidTitleEndDateRegression
   Scenario Outline: Validate error messages displayed when user fill invalid data for short project title and project end date
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     When I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     Then I validate '<Field_Error_Message>' and '<Summary_Error_Message>' displayed on project details title page for '<Project_Details_Title>'
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Third | Project_Details_Title                       | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Invalid_Data_Short_Project_Title_Max_Length | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Invalid_Data_Short_Project_Title_Min_Length | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Invalid_Day_Number                          | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Invalid_Day_Letters                         | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Invalid_Month_Number                        | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Invalid_Month_Letters                       | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Invalid_Year_Number_1                       | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Invalid_Year_Number_2                       | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Invalid_Year_Letters                        | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Invalid_Date_Past                           | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Invalid_Date_No_Day                         | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Invalid_Date_No_Month                       | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Invalid_Date_No_Year                        | Field_Error_Message | Summary_Error_Message |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Third | Navigation_Button_Add_Project | Project_Details_Title                       | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Invalid_Data_Short_Project_Title_Max_Length | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Invalid_Data_Short_Project_Title_Min_Length | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Invalid_Day_Number                          | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Invalid_Day_Letters                         | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Invalid_Month_Number                        | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Invalid_Month_Letters                       | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Invalid_Year_Number_1                       | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Invalid_Year_Number_2                       | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Invalid_Year_Letters                        | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Invalid_Date_Past                           | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Invalid_Date_No_Day                         | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Invalid_Date_No_Month                       | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Invalid_Date_No_Year                        | Field_Error_Message | Summary_Error_Message |
 
   @ErrorMessageInvalidKeyProjectRolesRegression
   Scenario Outline: Validate error messages displayed when user inputs invalid data in key project roles page
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     And I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     And I can see the key project roles page
@@ -145,39 +144,39 @@ Feature: Create Amendment - Create Project - Regression Tests
     And I capture the page screenshot
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Third | Project_Details_Title | Key_Project_Roles                                  | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Start_With_Dot                  | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Double_Dot                      | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Space                           | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Wrong_AT                        | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Less_Greater_Symbols            | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Colon                           | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Semi_Colon                      | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Comma                           | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Start_With_Hyphen               | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Hyphen_Before_Domain            | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Double_Dot_Domain               | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Exclamation_Domain              | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Unicode                         | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Single_Quote_Before_AT          | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Domain_Exceed_Max               | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Local_Part_Max                  | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Consecutive_Dot_Domain          | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Consecutive_Dot_SubDomain       | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Consecutiv_Dot_Domain_SubDomain | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Emoji                           | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_TLD                             | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Missing_AT                      | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Reserved_Domain                 | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Punycode                        | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Max_Char                        | Field_Error_Message | Summary_Error_Message |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Third | Navigation_Button_Add_Project | Project_Details_Title | Key_Project_Roles                                  | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Start_With_Dot                  | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Double_Dot                      | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Space                           | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Wrong_AT                        | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Less_Greater_Symbols            | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Colon                           | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Semi_Colon                      | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Comma                           | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Start_With_Hyphen               | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Hyphen_Before_Domain            | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Double_Dot_Domain               | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Exclamation_Domain              | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Unicode                         | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Single_Quote_Before_AT          | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Domain_Exceed_Max               | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Local_Part_Max                  | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Consecutive_Dot_Domain          | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Consecutive_Dot_SubDomain       | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Consecutiv_Dot_Domain_SubDomain | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Emoji                           | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_TLD                             | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Missing_AT                      | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Reserved_Domain                 | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Punycode                        | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Valid_Data_All_Fields | Invalid_Email_Data_Max_Char                        | Field_Error_Message | Summary_Error_Message |
 
   @CreateProjectJSEnabledRegression @jsEnabled
   Scenario Outline: Validate lead nation radio option when javascript is enabled
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     And I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     And I fill the key project roles page with '<Key_Project_Roles>'
@@ -187,16 +186,16 @@ Feature: Create Amendment - Create Project - Regression Tests
     Then I validate lead nation radio option for '<Research_Locations>'
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Third | Validation_Text | Project_Details_Title | Key_Project_Roles     | Research_Locations    |
-      | Create_Project_Record   | Start                    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Valid_Data_All_Fields |
-      | Create_Project_Record   | Start                    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Data_With_No_NHS_HSC  |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Third | Navigation_Button_Add_Project | Validation_Text | Project_Details_Title | Key_Project_Roles     | Research_Locations    |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Valid_Data_All_Fields |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Data_With_No_NHS_HSC  |
 
   @CreateProjectJSDisabledRegression @jsDisabled
   Scenario Outline: Validate lead nation radio option when javascript is disabled
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     And I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     And I fill the key project roles page with '<Key_Project_Roles>'
@@ -206,8 +205,8 @@ Feature: Create Amendment - Create Project - Regression Tests
     Then I validate lead nation radio option when javascript disabled
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Third | Validation_Text | Project_Details_Title | Key_Project_Roles     | Research_Locations   |
-      | Create_Project_Record   | Start                    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Data_With_No_NHS_HSC |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Third | Navigation_Button_Add_Project | Validation_Text | Project_Details_Title | Key_Project_Roles     | Research_Locations   |
+      | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Data_With_No_NHS_HSC |
 
   @CreateProjectRTSRegression @jsEnabled
   Scenario Outline: Validate the active primary sponsor organisation from rts with data in database

--- a/tests/features/cross-compatible/stories/regressionTests/CreateProject.feature
+++ b/tests/features/cross-compatible/stories/regressionTests/CreateProject.feature
@@ -5,7 +5,7 @@ Feature: Create Amendment - Create Project - Regression Tests
     Given I have navigated to the my research projects page
     And I can see the my research projects page
 
-  @CreateProjectValidRegression
+  @CreateProjectValidRegression @Smoke
   Scenario Outline: Validate user is able to amend a project
     # Validate labels in My_Research_Projects_Page
     And I can see the my research projects page
@@ -76,11 +76,29 @@ Feature: Create Amendment - Create Project - Regression Tests
     # Validate previously filled values persist on screen navigation for Research_Locations_Page
     Then I can see previously saved values for '<Research_Locations>' displayed on the research locations page
     And I capture the page screenshot
+    When I click the '<Navigation_Button_Third>' button on the 'Research_Locations_Page'
+    # Validate saved values in different pages is displayed in review answers page
+    Then I can see the review your application page
+    Then I can validate the field values of '<Project_Details_Title>' page '<Key_Project_Roles>' page and '<Research_Locations>' page
+    # Validate change link functionality in review answers page
+    And I click the change link '<Change_Link_Field>' on review your answers page
+    Then I can see the key project roles page
+    And I fill the key project roles page with '<Key_Project_Roles_Change>'
+    And I capture the page screenshot
+    When I click the 'Save_Changes' button on the 'Key_Project_Roles_Page'
+    Then I can see the review your answers page
+    And I capture the page screenshot
+    Then I can validate the field values of '<Project_Details_Title>' page '<Key_Project_Roles_Change>' page and '<Research_Locations>' page
+    And I capture the page screenshot
+    # Validate project overview page
+    When I click the '<Navigation_Button_Fourth>' button on the 'Review_Your_Answers_Page'
+    Then I can see the project overview page
+    And I capture the page screenshot
 
     Examples:
-      | Validation_Text | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Third | Navigation_Button_Add_Project | Navigation_Link | Project_Details_Title      | Key_Project_Roles                   | Research_Locations                     |
-      | Label_Texts     | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Back            | Valid_Data_All_Fields      | Valid_Data_All_Fields               | Data_With_No_NHS_HSC                   |
-      | Label_Texts     | Create_Project_Record   | Start                    | Save_Continue           | Add_Project                   | Back            | Valid_Data_All_Fields_VERA | Valid_Email_Data_Special_Characters | Data_With_Lead_Nation_Northern_Ireland |
+      | Validation_Text | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Third | Navigation_Button_Fourth | Navigation_Button_Add_Project | Navigation_Link | Project_Details_Title      | Key_Project_Roles                   | Research_Locations                     | Change_Link_Field  | Key_Project_Roles_Change                     |
+      | Label_Texts     | Create_Project_Record   | Start                    | Save_Continue           | Confirm_Project_Details  | Add_Project                   | Back            | Valid_Data_All_Fields      | Valid_Data_All_Fields               | Data_With_No_NHS_HSC                   | chief_investigator | Valid_Data_Only_Investigator_Email_Field_Two |
+      | Label_Texts     | Create_Project_Record   | Start                    | Save_Continue           | Confirm_Project_Details  | Add_Project                   | Back            | Valid_Data_All_Fields_VERA | Valid_Email_Data_Special_Characters | Data_With_Lead_Nation_Northern_Ireland | sponsor_contact    | Valid_Data_Only_Sponsor_Email_Field_Two      |
 
   @ErrorMessageInvalidIRASIDRegression
   Scenario Outline: Validate error messages displayed when user amend the project using invalid iras id

--- a/tests/features/cross-compatible/stories/systemTests/makeChanges/CreateProject.feature
+++ b/tests/features/cross-compatible/stories/systemTests/makeChanges/CreateProject.feature
@@ -8,14 +8,19 @@ Feature: Create Amendment - Create Project
   @rsp-1858 @rsp-1862
   Scenario Outline: Validate user is able to amend a project using an iras id
     And I can see the my research projects page
+    And I capture the page screenshot
     When I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     Then I can see the create project record page
+    And I capture the page screenshot
     When I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     Then I can see the project details iras page
+    And I capture the page screenshot
     And I can see the '<Validation_Text>' ui labels on the project details iras page
     And I fill the unique iras id in project details iras page
+    And I capture the page screenshot
     When I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     Then I can see the project details title page
+    And I capture the page screenshot
 
     Examples:
       | Validation_Text | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Link |

--- a/tests/features/cross-compatible/stories/systemTests/makeChanges/CreateProject.feature
+++ b/tests/features/cross-compatible/stories/systemTests/makeChanges/CreateProject.feature
@@ -32,8 +32,10 @@ Feature: Create Amendment - Create Project
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the project details iras page with '<Project_Details_IRAS>'
+    And I capture the page screenshot
     When I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     Then I validate '<Field_And_Summary_Error_Message>' displayed on 'Project_Details_IRAS_Page'
+    And I capture the page screenshot
 
     Examples:
       | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS             | Navigation_Button_Add_Project | Field_And_Summary_Error_Message           |
@@ -214,7 +216,7 @@ Feature: Create Amendment - Create Project
       | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Other_Language       | Back            |
 
   @rsp-1897
-  Scenario Outline: Validate error messages displayed when user inputs invalid data in key project roles page
+  Scenario Outline: Validate error messages displayed when user inputs invalid data for chief investigator email in key project roles page
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
@@ -229,32 +231,75 @@ Feature: Create Amendment - Create Project
     And I capture the page screenshot
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Project_Details_Title | Key_Project_Roles                                  | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Start_With_Dot                  | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Double_Dot                      | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Space                           | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Wrong_AT                        | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Less_Greater_Symbols            | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Colon                           | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Semi_Colon                      | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Comma                           | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Start_With_Hyphen               | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Hyphen_Before_Domain            | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Double_Dot_Domain               | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Exclamation_Domain              | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Unicode                         | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Single_Quote_Before_AT          | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Domain_Exceed_Max               | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Local_Part_Max                  | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Consecutive_Dot_Domain          | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Consecutive_Dot_SubDomain       | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Consecutiv_Dot_Domain_SubDomain | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Emoji                           | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_TLD                             | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Missing_AT                      | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Reserved_Domain                 | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Punycode                        | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Max_Char                        | Field_Error_Message | Summary_Error_Message |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Project_Details_Title | Key_Project_Roles                                      | Field_Error_Message     | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Start_With_Dot                  | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Double_Dot                      | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Space                           | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Wrong_AT                        | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Less_Greater_Symbols            | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Colon                           | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Semi_Colon                      | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Comma                           | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Start_With_Hyphen               | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Hyphen_Before_Domain            | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Double_Dot_Domain               | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Exclamation_Domain              | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Unicode                         | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Single_Quote_Before_AT          | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Domain_Exceed_Max               | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Local_Part_Max                  | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Consecutive_Dot_Domain          | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Consecutive_Dot_SubDomain       | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Consecutiv_Dot_Domain_SubDomain | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Emoji                           | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_TLD                             | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Missing_AT                      | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Reserved_Domain                 | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Punycode                        | Field_Error_Chief_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_One_Max_Char                        | Field_Error_Chief_Email | Summary_Error_Message |
+
+  @rsp-1897
+  Scenario Outline: Validate error messages displayed when user inputs invalid data for sponsor contact email in key project roles page
+    And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
+    And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
+    And I fill the unique iras id in project details iras page
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
+    And I fill the project details title page with '<Project_Details_Title>'
+    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
+    And I can see the key project roles page
+    Then I fill the key project roles page with '<Key_Project_Roles>'
+    And I capture the page screenshot
+    Then I click the '<Navigation_Button_Third>' button on the 'Key_Project_Roles_Page'
+    Then I validate '<Field_Error_Message>' and '<Summary_Error_Message>' displayed on key project roles page for '<Key_Project_Roles>'
+    And I capture the page screenshot
+
+    Examples:
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Project_Details_Title | Key_Project_Roles                                      | Field_Error_Message       | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Start_With_Dot                  | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Double_Dot                      | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Space                           | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Wrong_AT                        | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Less_Greater_Symbols            | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Colon                           | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Semi_Colon                      | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Comma                           | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Start_With_Hyphen               | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Hyphen_Before_Domain            | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Double_Dot_Domain               | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Exclamation_Domain              | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Unicode                         | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Single_Quote_Before_AT          | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Domain_Exceed_Max               | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Local_Part_Max                  | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Consecutive_Dot_Domain          | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Consecutive_Dot_SubDomain       | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Consecutiv_Dot_Domain_SubDomain | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Emoji                           | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_TLD                             | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Missing_AT                      | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Reserved_Domain                 | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Punycode                        | Field_Error_Sponsor_Email | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Two_Max_Char                        | Field_Error_Sponsor_Email | Summary_Error_Message |
 
   @rsp-1897
   Scenario Outline: Validate breadcrumb navigations in key project roles page

--- a/tests/features/cross-compatible/stories/systemTests/makeChanges/CreateProject.feature
+++ b/tests/features/cross-compatible/stories/systemTests/makeChanges/CreateProject.feature
@@ -55,8 +55,10 @@ Feature: Create Amendment - Create Project
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I can see the project details iras page
+    And I capture the page screenshot
     When I click the '<Navigation_Link>' link on the 'Project_Details_IRAS_Page'
     Then I can see the create project record page
+    And I capture the page screenshot
 
     Examples:
       | Navigation_Button_First | Navigation_Button_Second | Navigation_Link |
@@ -71,10 +73,13 @@ Feature: Create Amendment - Create Project
     Then I can see the project details title page
     Then I can see the '<Validation_Text>' ui labels on the project details title page
     Then I fill the project details title page with '<Project_Details_Title>'
+    And I capture the page screenshot
     When I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     Then I can see the key project roles page
+    And I capture the page screenshot
     When I click the '<Navigation_Link>' link on the 'Key_Project_Roles_Page'
     Then I can see previously saved values for '<Project_Details_Title>' displayed on the project details title page
+    And I capture the page screenshot
 
     Examples:
       | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Validation_Text | Project_Details_Title                         | Navigation_Link |
@@ -98,8 +103,10 @@ Feature: Create Amendment - Create Project
     And I fill the unique iras id in project details iras page
     And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
+    And I capture the page screenshot
     When I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     Then I validate '<Field_And_Summary_Error_Message>' displayed on 'Project_Details_Title_Page'
+    And I capture the page screenshot
 
     Examples:
       | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Project_Details_Title                       | Field_And_Summary_Error_Message |
@@ -125,8 +132,10 @@ Feature: Create Amendment - Create Project
     And I fill the unique iras id in project details iras page
     And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill todays date for planned project end date in project details title page
+    And I capture the page screenshot
     When I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     Then I validate '<Field_Error_Message>' and '<Summary_Error_Message>' displayed on project details title page for '<Project_Details_Title>'
+    And I capture the page screenshot
 
     Examples:
       | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Project_Details_Title | Field_Error_Message | Summary_Error_Message |

--- a/tests/features/cross-compatible/stories/systemTests/makeChanges/CreateProject.feature
+++ b/tests/features/cross-compatible/stories/systemTests/makeChanges/CreateProject.feature
@@ -5,7 +5,7 @@ Feature: Create Amendment - Create Project
     Given I have navigated to the my research projects page
     And I can see the my research projects page
 
-  @rsp-1858
+  @rsp-1858 @rsp-1862
   Scenario Outline: Validate user is able to amend a project using an iras id
     And I can see the my research projects page
     And I can see the '<Validation_Text>' on the my research project page
@@ -15,37 +15,35 @@ Feature: Create Amendment - Create Project
     Then I can see the project details iras page
     And I can see the '<Validation_Text>' ui labels on the project details iras page
     And I fill the unique iras id in project details iras page
-    When I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    When I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     Then I can see the project details title page
-    When I click the '<Navigation_Link>' link on the 'Project_Details_Title_Page'
-    Then I can see the project details iras page
 
     Examples:
-      | Validation_Text | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS | Navigation_Button_Third | Navigation_Link |
-      | Label_Texts     | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Back            |
-      | Label_Texts     | Create_Project_Record   | Start                    | Valid_IRAS_ID_Max    | Save_Continue           | Back            |
+      | Validation_Text | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Link |
+      | Label_Texts     | Create_Project_Record   | Start                    | Add_Project                   | Back            |
+      | Label_Texts     | Create_Project_Record   | Start                    | Add_Project                   | Back            |
 
   @rsp-1858 @rsp-1860 @invalidIrasIdValidations
   Scenario Outline: Validate error messages displayed when user amend the project using invalid iras id
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the project details iras page with '<Project_Details_IRAS>'
-    When I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    When I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     Then I validate '<Field_And_Summary_Error_Message>' displayed on 'Project_Details_IRAS_Page'
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS             | Navigation_Button_Third | Field_And_Summary_Error_Message           |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Letters          | Save_Continue           | Field_Error_Message                       |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Symbols          | Save_Continue           | Field_Error_Message                       |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Letters_Symbols  | Save_Continue           | Field_Error_Message                       |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Min_Length       | Save_Continue           | Field_Error_Message_Iras_Id_Length        |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Max_Length       | Save_Continue           | Field_Error_Message                       |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Leading_Zeros    | Save_Continue           | Field_Error_Message_Iras_Id_Leading_Zeros |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces           | Save_Continue           | Field_Error_Message_Iras_Id_Mandatory     |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces_Suffix    | Save_Continue           | Field_Error_Message                       |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces_Prefix    | Save_Continue           | Field_Error_Message                       |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces_Seperator | Save_Continue           | Field_Error_Message                       |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Blank            | Save_Continue           | Field_Error_Message_Iras_Id_Mandatory     |
+      | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS             | Navigation_Button_Add_Project | Field_And_Summary_Error_Message           |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Letters          | Add_Project                   | Field_Error_Message                       |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Symbols          | Add_Project                   | Field_Error_Message                       |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Letters_Symbols  | Add_Project                   | Field_Error_Message                       |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Min_Length       | Add_Project                   | Field_Error_Message_Iras_Id_Length        |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Max_Length       | Add_Project                   | Field_Error_Message                       |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Leading_Zeros    | Add_Project                   | Field_Error_Message_Iras_Id_Leading_Zeros |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces           | Add_Project                   | Field_Error_Message_Iras_Id_Mandatory     |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces_Suffix    | Add_Project                   | Field_Error_Message                       |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces_Prefix    | Add_Project                   | Field_Error_Message                       |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces_Seperator | Add_Project                   | Field_Error_Message                       |
+      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Blank            | Add_Project                   | Field_Error_Message_Iras_Id_Mandatory     |
 
   @rsp-1858
   Scenario Outline: Validate breadcrumb navigations in project details iras id page
@@ -64,7 +62,7 @@ Feature: Create Amendment - Create Project
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    When I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    When I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     Then I can see the project details title page
     Then I can see the '<Validation_Text>' ui labels on the project details title page
     Then I fill the project details title page with '<Project_Details_Title>'
@@ -74,81 +72,98 @@ Feature: Create Amendment - Create Project
     Then I can see previously saved values for '<Project_Details_Title>' displayed on the project details title page
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS | Navigation_Button_Third | Validation_Text | Project_Details_Title                         | Navigation_Link |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields                         | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_VERA                    | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_CSL                     | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_Special_Character_One   | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_Special_Character_Two   | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_Special_Character_Three | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_Special_Character_Four  | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_PARTRIDGE               | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_OMEGA                   | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_Ferumoxytol             | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_Special_Character_Five  | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_Special_Character_Six   | Back            |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Validation_Text | Project_Details_Title                         | Navigation_Link |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields                         | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_VERA                    | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_CSL                     | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_Special_Character_One   | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_Special_Character_Two   | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_Special_Character_Three | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_Special_Character_Four  | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_PARTRIDGE               | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_OMEGA                   | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_Ferumoxytol             | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_Special_Character_Five  | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields_Special_Character_Six   | Back            |
 
   @rsp-1859
   Scenario Outline: Validate error messages displayed when user fill invalid data for short project title and project end date
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     When I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     Then I validate '<Field_And_Summary_Error_Message>' displayed on 'Project_Details_Title_Page'
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS | Navigation_Button_Third | Project_Details_Title                       | Field_And_Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Invalid_All_Fields                          | All_Field_Error_Message         |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Invalid_Data_Short_Project_Title_Max_Length | Title_Field_Error_Message       |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Invalid_Data_Short_Project_Title_Min_Length | Title_Field_Error_Message       |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Invalid_Day_Number                          | Date_Day_Field_Error_Message    |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Invalid_Day_Letters                         | Date_Day_Field_Error_Message    |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Invalid_Month_Number                        | Date_Month_Field_Error_Message  |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Invalid_Month_Letters                       | Date_Month_Field_Error_Message  |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Invalid_Year_Number_1                       | Date_Year_Field_Error_Message   |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Invalid_Year_Number_2                       | Date_Year_Field_Error_Message   |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Invalid_Year_Letters                        | Date_Year_Field_Error_Message   |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Invalid_Date_Past                           | Date_Day_Field_Error_Message    |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Invalid_Date_No_Day                         | Date_Day_Field_Error_Message    |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Invalid_Date_No_Month                       | Date_Month_Field_Error_Message  |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Invalid_Date_No_Year                        | Date_Year_Field_Error_Message   |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Project_Details_Title                       | Field_And_Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Invalid_All_Fields                          | All_Field_Error_Message         |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Invalid_Data_Short_Project_Title_Max_Length | Title_Field_Error_Message       |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Invalid_Data_Short_Project_Title_Min_Length | Title_Field_Error_Message       |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Invalid_Day_Number                          | Date_Day_Field_Error_Message    |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Invalid_Day_Letters                         | Date_Day_Field_Error_Message    |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Invalid_Month_Number                        | Date_Month_Field_Error_Message  |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Invalid_Month_Letters                       | Date_Month_Field_Error_Message  |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Invalid_Year_Number_1                       | Date_Year_Field_Error_Message   |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Invalid_Year_Number_2                       | Date_Year_Field_Error_Message   |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Invalid_Year_Letters                        | Date_Year_Field_Error_Message   |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Invalid_Date_Past                           | Date_Day_Field_Error_Message    |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Invalid_Date_No_Day                         | Date_Day_Field_Error_Message    |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Invalid_Date_No_Month                       | Date_Month_Field_Error_Message  |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Invalid_Date_No_Year                        | Date_Year_Field_Error_Message   |
 
   @rsp-1859
   Scenario Outline: Validate error messages displayed when user fill todays date for project end date
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill todays date for planned project end date in project details title page
     When I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     Then I validate '<Field_Error_Message>' and '<Summary_Error_Message>' displayed on project details title page for '<Project_Details_Title>'
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS | Navigation_Button_Third | Project_Details_Title | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Invalid_Date_Today    | Field_Error_Message | Summary_Error_Message |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Project_Details_Title | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Invalid_Date_Today    | Field_Error_Message | Summary_Error_Message |
 
-  @rsp-1859
+  @rsp-1859 @rsp-1865 @jsEnabled
   Scenario Outline: Validate breadcrumb navigations in project details short project title page
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I can see the project details title page
-    When I click the '<Navigation_Link>' link on the 'Project_Details_Title_Page'
-    Then I can see the project details iras page
+    And I cannot see a '<Navigation_Link>' link on the 'Project_Details_Title_Page'
+    And I capture the page screenshot
+    Then I fill the project details title page with '<Project_Details_Title>'
+    When I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
+    Then I fill the key project roles page with '<Key_Project_Roles>'
+    Then I click the '<Navigation_Button_Third>' button on the 'Key_Project_Roles_Page'
+    Then I fill the research locations page with '<Research_Locations>'
+    When I click the '<Navigation_Button_Third>' button on the 'Research_Locations_Page'
+    Then I can see the review your answers page
+    And I click the change link '<Change_Link_Field>' on review your answers page
+    And I capture the page screenshot
+    And I click the '<Navigation_Link>' link on the 'Project_Details_Title_Page'
+    Then I can see the review your answers page
+    When I click the '<Navigation_Button_Fourth>' button on the 'Review_Your_Answers_Page'
+    Then I can see the project overview page
+    When I click the '<Navigation_Link_Second>' link on the 'Project_Overview_Page'
+    And I can see the project details title page
+    And I capture the page screenshot
+    And I cannot see a '<Navigation_Link>' link on the 'Project_Details_Title_Page'
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS | Navigation_Button_Third | Navigation_Link |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Back            |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Navigation_Button_Fourth | Navigation_Link | Navigation_Link_Second | Project_Details_Title | Key_Project_Roles     | Research_Locations    | Change_Link_Field |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Confirm_Project_Details  | Back            | Project_Details        | Valid_Data_All_Fields | Valid_Data_All_Fields | Valid_Data_All_Fields | Project_Title     |
 
   @rsp-1897
   Scenario Outline: Validate user is able to fill key project roles page with valid data
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     When I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     Then I can see the key project roles page
@@ -164,41 +179,41 @@ Feature: Create Amendment - Create Project
     And I capture the page screenshot
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS | Navigation_Button_Third | Validation_Text | Project_Details_Title | Key_Project_Roles                     | Navigation_Link |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields                 | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data                      | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Underscore                | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Hyphen               | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Plus                 | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Exclamation          | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Hash                 | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Dollar               | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Percentage           | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Ampersand            | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Single_Quote         | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Star                 | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Slash                | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Equal_Symbol         | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Question_Mark        | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Cap_Symbol           | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Right_Single_Quote   | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Curly_Brackets       | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Pipe_Symbol          | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Tilde_Symbol         | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Unicode              | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Special_Characters   | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Hyphen_Underscore    | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Multiple_Unicode     | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Multiple_Sub_Domains | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Domain               | Back            |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Other_Language       | Back            |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Validation_Text | Project_Details_Title | Key_Project_Roles                     | Navigation_Link |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields                 | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data                      | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Underscore                | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Hyphen               | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Plus                 | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Exclamation          | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Hash                 | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Dollar               | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Percentage           | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Ampersand            | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Single_Quote         | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Star                 | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Slash                | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Equal_Symbol         | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Question_Mark        | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Cap_Symbol           | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Right_Single_Quote   | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Curly_Brackets       | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Pipe_Symbol          | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Tilde_Symbol         | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Unicode              | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Special_Characters   | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Hyphen_Underscore    | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Multiple_Unicode     | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Multiple_Sub_Domains | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Domain               | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Email_Data_Other_Language       | Back            |
 
   @rsp-1897
   Scenario Outline: Validate error messages displayed when user inputs invalid data in key project roles page
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     And I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     And I can see the key project roles page
@@ -209,39 +224,39 @@ Feature: Create Amendment - Create Project
     And I capture the page screenshot
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS | Navigation_Button_Third | Project_Details_Title | Key_Project_Roles                                  | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Start_With_Dot                  | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Double_Dot                      | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Space                           | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Wrong_AT                        | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Less_Greater_Symbols            | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Colon                           | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Semi_Colon                      | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Comma                           | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Start_With_Hyphen               | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Hyphen_Before_Domain            | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Double_Dot_Domain               | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Exclamation_Domain              | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Unicode                         | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Single_Quote_Before_AT          | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Domain_Exceed_Max               | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Local_Part_Max                  | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Consecutive_Dot_Domain          | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Consecutive_Dot_SubDomain       | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Consecutiv_Dot_Domain_SubDomain | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Emoji                           | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_TLD                             | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Missing_AT                      | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Reserved_Domain                 | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Punycode                        | Field_Error_Message | Summary_Error_Message |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Max_Char                        | Field_Error_Message | Summary_Error_Message |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Project_Details_Title | Key_Project_Roles                                  | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Start_With_Dot                  | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Double_Dot                      | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Space                           | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Wrong_AT                        | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Less_Greater_Symbols            | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Colon                           | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Semi_Colon                      | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Comma                           | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Start_With_Hyphen               | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Hyphen_Before_Domain            | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Double_Dot_Domain               | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Exclamation_Domain              | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Unicode                         | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Single_Quote_Before_AT          | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Domain_Exceed_Max               | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Local_Part_Max                  | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Consecutive_Dot_Domain          | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Consecutive_Dot_SubDomain       | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Consecutiv_Dot_Domain_SubDomain | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Emoji                           | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_TLD                             | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Missing_AT                      | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Reserved_Domain                 | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Punycode                        | Field_Error_Message | Summary_Error_Message |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Invalid_Email_Data_Max_Char                        | Field_Error_Message | Summary_Error_Message |
 
   @rsp-1897
   Scenario Outline: Validate breadcrumb navigations in key project roles page
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     And I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     And I can see the key project roles page
@@ -251,15 +266,15 @@ Feature: Create Amendment - Create Project
     And I capture the page screenshot
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS | Navigation_Button_Third | Project_Details_Title | Navigation_Link |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Back            |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Project_Details_Title | Navigation_Link |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Back            |
 
   @rsp-1901
   Scenario Outline: Validate user is able to fill research locations page
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     And I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     And I fill the key project roles page with '<Key_Project_Roles>'
@@ -274,19 +289,19 @@ Feature: Create Amendment - Create Project
     Then I can see previously saved values for '<Research_Locations>' displayed on the research locations page
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS | Navigation_Button_Third | Validation_Text | Project_Details_Title | Key_Project_Roles     | Research_Locations                     |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Valid_Data_All_Fields                  |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Data_With_No_NHS_HSC                   |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Data_With_Lead_Nation_Northern_Ireland |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Data_With_Lead_Nation_Scotland         |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Data_With_Lead_Nation_Wales            |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Validation_Text | Project_Details_Title | Key_Project_Roles     | Research_Locations                     |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Valid_Data_All_Fields                  |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Data_With_No_NHS_HSC                   |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Data_With_Lead_Nation_Northern_Ireland |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Data_With_Lead_Nation_Scotland         |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Data_With_Lead_Nation_Wales            |
 
   @rsp-1901 @jsEnabled
   Scenario Outline: Validate lead nation radio option when javascript is enabled
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     And I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     And I fill the key project roles page with '<Key_Project_Roles>'
@@ -296,16 +311,16 @@ Feature: Create Amendment - Create Project
     Then I validate lead nation radio option for '<Research_Locations>'
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS | Navigation_Button_Third | Validation_Text | Project_Details_Title | Key_Project_Roles     | Research_Locations    |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Valid_Data_All_Fields |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Data_With_No_NHS_HSC  |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Validation_Text | Project_Details_Title | Key_Project_Roles     | Research_Locations    |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Valid_Data_All_Fields |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Data_With_No_NHS_HSC  |
 
   @rsp-1901 @jsDisabled
   Scenario Outline: Validate lead nation radio option when javascript is disabled
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     And I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     And I fill the key project roles page with '<Key_Project_Roles>'
@@ -315,15 +330,15 @@ Feature: Create Amendment - Create Project
     Then I validate lead nation radio option when javascript disabled
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS | Navigation_Button_Third | Validation_Text | Project_Details_Title | Key_Project_Roles     | Research_Locations   |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Data_With_No_NHS_HSC |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Validation_Text | Project_Details_Title | Key_Project_Roles     | Research_Locations   |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Data_With_No_NHS_HSC |
 
   @rsp-1901
   Scenario Outline: Validate breadcrumb navigations in research locations page
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     And I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     And I fill the key project roles page with '<Key_Project_Roles>'
@@ -333,8 +348,8 @@ Feature: Create Amendment - Create Project
     Then I can see the key project roles page
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Project_Details_IRAS | Navigation_Button_Third | Project_Details_Title | Key_Project_Roles     | Navigation_Link |
-      | Create_Project_Record   | Start                    | Valid_IRAS_ID_Min    | Save_Continue           | Valid_Data_All_Fields | Valid_Data_All_Fields | Back            |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Project_Details_Title | Key_Project_Roles     | Navigation_Link |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Valid_Data_All_Fields | Back            |
 
   @rsp-1860 @duplicateIrasIdValidation
   Scenario Outline: Verify the duplicate IRAS ID error message when user enters the existing IRAS ID
@@ -342,7 +357,7 @@ Feature: Create Amendment - Create Project
     And I click the 'Start' button on the 'Create_Project_Record_Page'
     Then I can see the project details iras page
     And I fill the unique iras id in project details iras page
-    And I click the 'Save_Continue' button on the 'Project_Details_IRAS_Page'
+    And I click the 'Add_Project' button on the 'Project_Details_IRAS_Page'
     Then I can see the project details title page
     And I have navigated to the my research projects page
     And I can see the my research projects page
@@ -350,12 +365,12 @@ Feature: Create Amendment - Create Project
     And I click the 'Start' button on the 'Create_Project_Record_Page'
     Then I can see the project details iras page
     And I fill the existing iras id in project details iras page
-    When I click the 'Save_Continue' button on the 'Project_Details_IRAS_Page'
+    When I click the 'Add_Project' button on the 'Project_Details_IRAS_Page'
     Then I validate '<Field_And_Summary_Error_Message>' displayed on 'Project_Details_IRAS_Page'
 
     Examples:
-      | Project_Details_IRAS      | Field_And_Summary_Error_Message       |
-      | Invalid_IRAS_ID_Duplicate | Field_Error_Message_Iras_Id_Duplicate |
+      | Field_And_Summary_Error_Message       |
+      | Field_Error_Message_Iras_Id_Duplicate |
 
   @rsp-1863 @saveLaterProjectTitle
   Scenario Outline: Verify product details are saved when user saves the record on create project - Project details page
@@ -364,7 +379,7 @@ Feature: Create Amendment - Create Project
     Then I can see the project details iras page
     And I fill the unique iras id in project details iras page
     And I capture the page screenshot
-    And I click the 'Save_Continue' button on the 'Project_Details_IRAS_Page'
+    And I click the 'Add_Project' button on the 'Project_Details_IRAS_Page'
     Then I can see the project details title page
     And I fill the project details title page with '<Project_Details_Title>'
     And I capture the page screenshot
@@ -372,7 +387,7 @@ Feature: Create Amendment - Create Project
     Then I can see the project overview page
     And I capture the page screenshot
     And I can see the short project title on project overview page for '<Project_Details_Title>'
-    When I click the 'Project_Details' link on the 'Project_Overview_Save_For_Later_Page'
+    When I click the 'Project_Details' link on the 'Project_Overview_Page'
     And I can see the project details title page
     And I capture the page screenshot
     Then I can see previously saved values for '<Project_Details_Title>' displayed on the project details title page
@@ -391,7 +406,7 @@ Feature: Create Amendment - Create Project
     Then I can see the project details iras page
     And I fill the unique iras id in project details iras page
     And I capture the page screenshot
-    And I click the 'Save_Continue' button on the 'Project_Details_IRAS_Page'
+    And I click the 'Add_Project' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     And I capture the page screenshot
     When I click the 'Save_Continue' button on the 'Project_Details_Title_Page'
@@ -401,7 +416,7 @@ Feature: Create Amendment - Create Project
     Then I can see the project overview page
     And I capture the page screenshot
     And I can see the short project title on project overview page for '<Project_Details_Title>'
-    When I click the 'Project_Details' link on the 'Project_Overview_Save_For_Later_Page'
+    When I click the 'Project_Details' link on the 'Project_Overview_Page'
     Then I can see the project details title page
     And I capture the page screenshot
     And I click the 'Save_Continue' button on the 'Project_Details_Title_Page'
@@ -423,7 +438,7 @@ Feature: Create Amendment - Create Project
     Then I can see the project details iras page
     And I fill the unique iras id in project details iras page
     And I capture the page screenshot
-    And I click the 'Save_Continue' button on the 'Project_Details_IRAS_Page'
+    And I click the 'Add_Project' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     And I capture the page screenshot
     When I click the 'Save_Continue' button on the 'Project_Details_Title_Page'
@@ -436,7 +451,7 @@ Feature: Create Amendment - Create Project
     Then I can see the project overview page
     And I capture the page screenshot
     And I can see the short project title on project overview page for '<Project_Details_Title>'
-    When I click the 'Project_Details' link on the 'Project_Overview_Save_For_Later_Page'
+    When I click the 'Project_Details' link on the 'Project_Overview_Page'
     Then I can see the project details title page
     And I capture the page screenshot
     And I click the 'Save_Continue' button on the 'Project_Details_Title_Page'
@@ -459,7 +474,7 @@ Feature: Create Amendment - Create Project
     And I click the 'Start' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
     And I capture the page screenshot
-    And I click the 'Save_Continue' button on the 'Project_Details_IRAS_Page'
+    And I click the 'Add_Project' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     When I click the 'Save_For_Later' button on the 'Project_Details_Title_Page'
     And I capture the page screenshot
@@ -488,7 +503,7 @@ Feature: Create Amendment - Create Project
     And I click the 'Start' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
     And I capture the page screenshot
-    And I click the 'Save_Continue' button on the 'Project_Details_IRAS_Page'
+    And I click the 'Add_Project' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     And I capture the page screenshot
     And I click the 'Save_Continue' button on the 'Project_Details_Title_Page'
@@ -533,7 +548,7 @@ Feature: Create Amendment - Create Project
     And I click the 'Start' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
     And I capture the page screenshot
-    And I click the 'Save_Continue' button on the 'Project_Details_IRAS_Page'
+    And I click the 'Add_Project' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     And I capture the page screenshot
     And I click the 'Save_Continue' button on the 'Project_Details_Title_Page'
@@ -577,7 +592,7 @@ Feature: Create Amendment - Create Project
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     When I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     Then I can see the key project roles page
@@ -623,20 +638,20 @@ Feature: Create Amendment - Create Project
     And I capture the page screenshot
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Third | Validation_Text | Project_Details_Title | Key_Project_Roles     | Key_Project_Roles_Change               | Key_Project_Roles_Change_Blank  | Research_Locations    | Change_Link_Field            | Enter_Link_Field             | Navigation_Link |
-      | Create_Project_Record   | Start                    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Sponsor_Organisation_Full_Text_Aalborg | Sponsor_Organisation_Text_Blank | Valid_Data_All_Fields | primary_sponsor_organisation | primary_sponsor_organisation | Back            |
-      | Create_Project_Record   | Start                    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Sponsor_Organisation_Text_Brackets     | Sponsor_Organisation_Text_Blank | Valid_Data_All_Fields | primary_sponsor_organisation | primary_sponsor_organisation | Back            |
-      | Create_Project_Record   | Start                    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Sponsor_Organisation_Text_Amp          | Sponsor_Organisation_Text_Blank | Valid_Data_All_Fields | primary_sponsor_organisation | primary_sponsor_organisation | Back            |
-      | Create_Project_Record   | Start                    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Sponsor_Organisation_Text_Dot_Comma    | Sponsor_Organisation_Text_Blank | Valid_Data_All_Fields | primary_sponsor_organisation | primary_sponsor_organisation | Back            |
-      | Create_Project_Record   | Start                    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Sponsor_Organisation_Text_Slash        | Sponsor_Organisation_Text_Blank | Valid_Data_All_Fields | primary_sponsor_organisation | primary_sponsor_organisation | Back            |
-      | Create_Project_Record   | Start                    | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Sponsor_Organisation_Text_Hyphen       | Sponsor_Organisation_Text_Blank | Valid_Data_All_Fields | primary_sponsor_organisation | primary_sponsor_organisation | Back            |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Validation_Text | Project_Details_Title | Key_Project_Roles     | Key_Project_Roles_Change               | Key_Project_Roles_Change_Blank  | Research_Locations    | Change_Link_Field            | Enter_Link_Field             | Navigation_Link |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Sponsor_Organisation_Full_Text_Aalborg | Sponsor_Organisation_Text_Blank | Valid_Data_All_Fields | primary_sponsor_organisation | primary_sponsor_organisation | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Sponsor_Organisation_Text_Brackets     | Sponsor_Organisation_Text_Blank | Valid_Data_All_Fields | primary_sponsor_organisation | primary_sponsor_organisation | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Sponsor_Organisation_Text_Amp          | Sponsor_Organisation_Text_Blank | Valid_Data_All_Fields | primary_sponsor_organisation | primary_sponsor_organisation | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Sponsor_Organisation_Text_Dot_Comma    | Sponsor_Organisation_Text_Blank | Valid_Data_All_Fields | primary_sponsor_organisation | primary_sponsor_organisation | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Sponsor_Organisation_Text_Slash        | Sponsor_Organisation_Text_Blank | Valid_Data_All_Fields | primary_sponsor_organisation | primary_sponsor_organisation | Back            |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Label_Texts     | Valid_Data_All_Fields | Valid_Data_All_Fields | Sponsor_Organisation_Text_Hyphen       | Sponsor_Organisation_Text_Blank | Valid_Data_All_Fields | primary_sponsor_organisation | primary_sponsor_organisation | Back            |
 
   @rsp-1861 @rsp-3670 @jsEnabled
   Scenario Outline: Validate the primary sponsor organisation suggestion list in key project roles page
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
     And I fill the unique iras id in project details iras page
-    And I click the '<Navigation_Button_Third>' button on the 'Project_Details_IRAS_Page'
+    And I click the '<Navigation_Button_Add_Project>' button on the 'Project_Details_IRAS_Page'
     And I fill the project details title page with '<Project_Details_Title>'
     When I click the '<Navigation_Button_Third>' button on the 'Project_Details_Title_Page'
     Then I can see the key project roles page
@@ -649,14 +664,14 @@ Feature: Create Amendment - Create Project
     And I capture the page screenshot
 
     Examples:
-      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Third | Project_Details_Title | Sponsor_Organisation                          | Sponsor_Organisation_Invalid      | Sponsor_Organisation_Min      | Suggestion_List_Headers        | RTS_API_Data         | RTS_Request                                 |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Sponsor_Organisation_Partial_Text_NHS         | Sponsor_Organisation_Invalid_Data | Sponsor_Organisation_Min_Char | Suggestion_List_Common_Headers | RTS_NIHR_FHIR_Config | RTS_Active_Sponsor_Organisation_NHS         |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Sponsor_Organisation_Text_Partial_Brackets    | Sponsor_Organisation_Invalid_Data | Sponsor_Organisation_Min_Char | Suggestion_List_Common_Headers | RTS_NIHR_FHIR_Config | RTS_Active_Sponsor_Organisation_Brackets    |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Sponsor_Organisation_Text_Partial_Dot_Comma   | Sponsor_Organisation_Invalid_Data | Sponsor_Organisation_Min_Char | Suggestion_List_Common_Headers | RTS_NIHR_FHIR_Config | RTS_Active_Sponsor_Organisation_Dot_Comma   |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Sponsor_Organisation_Text_Partial_Slash       | Sponsor_Organisation_Invalid_Data | Sponsor_Organisation_Min_Char | Suggestion_List_Common_Headers | RTS_NIHR_FHIR_Config | RTS_Active_Sponsor_Organisation_Slash       |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Sponsor_Organisation_Text_Partial_Hyphen      | Sponsor_Organisation_Invalid_Data | Sponsor_Organisation_Min_Char | Suggestion_List_Common_Headers | RTS_NIHR_FHIR_Config | RTS_Active_Sponsor_Organisation_Hyphen      |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Sponsor_Organisation_Text_Partial_Start_Space | Sponsor_Organisation_Invalid_Data | Sponsor_Organisation_Min_Char | Suggestion_List_Common_Headers | RTS_NIHR_FHIR_Config | RTS_Active_Sponsor_Organisation_Start_Space |
-      | Create_Project_Record   | Start                    | Save_Continue           | Valid_Data_All_Fields | Sponsor_Organisation_Text_Partial_End_Space   | Sponsor_Organisation_Invalid_Data | Sponsor_Organisation_Min_Char | Suggestion_List_Common_Headers | RTS_NIHR_FHIR_Config | RTS_Active_Sponsor_Organisation_Ends_Space  |
+      | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Project_Details_Title | Sponsor_Organisation                          | Sponsor_Organisation_Invalid      | Sponsor_Organisation_Min      | Suggestion_List_Headers        | RTS_API_Data         | RTS_Request                                 |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Sponsor_Organisation_Partial_Text_NHS         | Sponsor_Organisation_Invalid_Data | Sponsor_Organisation_Min_Char | Suggestion_List_Common_Headers | RTS_NIHR_FHIR_Config | RTS_Active_Sponsor_Organisation_NHS         |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Sponsor_Organisation_Text_Partial_Brackets    | Sponsor_Organisation_Invalid_Data | Sponsor_Organisation_Min_Char | Suggestion_List_Common_Headers | RTS_NIHR_FHIR_Config | RTS_Active_Sponsor_Organisation_Brackets    |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Sponsor_Organisation_Text_Partial_Dot_Comma   | Sponsor_Organisation_Invalid_Data | Sponsor_Organisation_Min_Char | Suggestion_List_Common_Headers | RTS_NIHR_FHIR_Config | RTS_Active_Sponsor_Organisation_Dot_Comma   |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Sponsor_Organisation_Text_Partial_Slash       | Sponsor_Organisation_Invalid_Data | Sponsor_Organisation_Min_Char | Suggestion_List_Common_Headers | RTS_NIHR_FHIR_Config | RTS_Active_Sponsor_Organisation_Slash       |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Sponsor_Organisation_Text_Partial_Hyphen      | Sponsor_Organisation_Invalid_Data | Sponsor_Organisation_Min_Char | Suggestion_List_Common_Headers | RTS_NIHR_FHIR_Config | RTS_Active_Sponsor_Organisation_Hyphen      |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Sponsor_Organisation_Text_Partial_Start_Space | Sponsor_Organisation_Invalid_Data | Sponsor_Organisation_Min_Char | Suggestion_List_Common_Headers | RTS_NIHR_FHIR_Config | RTS_Active_Sponsor_Organisation_Start_Space |
+      | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Valid_Data_All_Fields | Sponsor_Organisation_Text_Partial_End_Space   | Sponsor_Organisation_Invalid_Data | Sponsor_Organisation_Min_Char | Suggestion_List_Common_Headers | RTS_NIHR_FHIR_Config | RTS_Active_Sponsor_Organisation_Ends_Space  |
 
   @rsp-1861 @jsEnabled
   Scenario Outline: Validate the active primary sponsor organisation from rts with data in database

--- a/tests/features/cross-compatible/stories/systemTests/makeChanges/CreateProject.feature
+++ b/tests/features/cross-compatible/stories/systemTests/makeChanges/CreateProject.feature
@@ -8,7 +8,6 @@ Feature: Create Amendment - Create Project
   @rsp-1858 @rsp-1862
   Scenario Outline: Validate user is able to amend a project using an iras id
     And I can see the my research projects page
-    And I can see the '<Validation_Text>' on the my research project page
     When I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     Then I can see the create project record page
     When I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'

--- a/tests/features/cross-compatible/stories/systemTests/makeChanges/CreateProject.feature
+++ b/tests/features/cross-compatible/stories/systemTests/makeChanges/CreateProject.feature
@@ -127,7 +127,7 @@ Feature: Create Amendment - Create Project
       | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Project_Details_Title | Field_Error_Message | Summary_Error_Message |
       | Create_Project_Record   | Start                    | Add_Project                   | Save_Continue           | Invalid_Date_Today    | Field_Error_Message | Summary_Error_Message |
 
-  @rsp-1859 @rsp-1865 @jsEnabled
+  @rsp-1859 @rsp-1865
   Scenario Outline: Validate breadcrumb navigations in project details short project title page
     And I click the '<Navigation_Button_First>' button on the 'My_Research_Projects_Page'
     And I click the '<Navigation_Button_Second>' button on the 'Create_Project_Record_Page'
@@ -152,7 +152,8 @@ Feature: Create Amendment - Create Project
     When I click the '<Navigation_Link_Second>' link on the 'Project_Overview_Page'
     And I can see the project details title page
     And I capture the page screenshot
-    And I cannot see a '<Navigation_Link>' link on the 'Project_Details_Title_Page'
+    And I click the '<Navigation_Link>' link on the 'Project_Details_Title_Page'
+    Then I can see the project overview page
 
     Examples:
       | Navigation_Button_First | Navigation_Button_Second | Navigation_Button_Add_Project | Navigation_Button_Third | Navigation_Button_Fourth | Navigation_Link | Navigation_Link_Second | Project_Details_Title | Key_Project_Roles     | Research_Locations    | Change_Link_Field |

--- a/tests/features/cross-compatible/stories/systemTests/makeChanges/CreateProject.feature
+++ b/tests/features/cross-compatible/stories/systemTests/makeChanges/CreateProject.feature
@@ -43,7 +43,6 @@ Feature: Create Amendment - Create Project
       | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Symbols          | Add_Project                   | Field_Error_Message                       |
       | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Letters_Symbols  | Add_Project                   | Field_Error_Message                       |
       | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Min_Length       | Add_Project                   | Field_Error_Message_Iras_Id_Length        |
-      | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Max_Length       | Add_Project                   | Field_Error_Message                       |
       | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Leading_Zeros    | Add_Project                   | Field_Error_Message_Iras_Id_Leading_Zeros |
       | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces           | Add_Project                   | Field_Error_Message_Iras_Id_Mandatory     |
       | Create_Project_Record   | Start                    | Invalid_IRAS_ID_Spaces_Suffix    | Add_Project                   | Field_Error_Message                       |

--- a/tests/features/cross-compatible/stories/systemTests/reviewResearch/userAdministration/MyResearch.feature
+++ b/tests/features/cross-compatible/stories/systemTests/reviewResearch/userAdministration/MyResearch.feature
@@ -5,7 +5,7 @@ Feature: User Administration: My Research
     Given I have navigated to the 'Home_Page'
     And I can see the my account home page
 
-  @rsp-3424 @myResearchProjectsPage
+  @rsp-3424 @myResearchProjectsPage @Smoke
   Scenario Outline: Validate the my research page and Navigation back to home page
     Given I have navigated to the 'My_Research_Page'
     Then I can see the 'My_Research_Page'


### PR DESCRIPTION
## What was the purpose of this ticket?
Re-label 'save and continue' button
Remove 'back' link from project details page

## Jira Ref
[RSP-1862](https://nihr.atlassian.net/browse/RSP-1862)
[RSP-1865](https://nihr.atlassian.net/browse/RSP-1865)

## Type of Change

Put [X] inside the [] to make the box ticked

- [X] New Tests
- [X] Updating Tests
- [] Fixing Tests
- [] Framework Improvements
- [] Documentation

## Solution

What work was completed to cover off the story?
Updated button text for 'save and continue' to 'Add project'
Validated 'back' link is not displayed in project details page

## Checklist

Put [X] inside the [] to make the box ticked

- [X] Your code builds clean without any warnings, i.e. no ESLint or SonarCube errors
- [X] You have run the Pipeline jobs against this branch successfully
- [X] Any new or updated tests add value, i.e. provide correct assurances, fail when expected and log errors appropriately
- [X] Tests have been tagged appropriately
- [X] No duplicate tests, steps or functions have been added
- [X] You are using the correct naming conventions
- [X] Added files have been placed correctly within the projects folder structure
- [X] There is no dead code e.g. no "TODO" comments left, no unused imports etc
- [X] Any Framework updates have been explained and demonstrated to the team
