### PR TITLE
Regression fix edit user audit history

### DIFF
--- a/src/pages/IRAS/reviewResearch/userAdministration/manageUsers/EditUserProfilePage.ts
+++ b/src/pages/IRAS/reviewResearch/userAdministration/manageUsers/EditUserProfilePage.ts
@@ -27,13 +27,11 @@ export default class EditUserProfilePage {
   readonly review_body_dropdown: Locator;
   readonly country_label: Locator;
   readonly access_required_label: Locator;
-  private _title: string;
 
   //Initialize Page Objects
   constructor(page: Page) {
     this.page = page;
     this.editUserProfilePageTestData = editUserProfilePageTestData;
-    this._title = '';
 
     //Locators
     this.page_heading = this.page
@@ -145,13 +143,5 @@ export default class EditUserProfilePage {
       }
     }
     return checkedLabels;
-  }
-
-  async getUniqueTitle(): Promise<string> {
-    return this._title;
-  }
-
-  async setUniqueTitle(value: string): Promise<void> {
-    this._title = value;
   }
 }

--- a/src/pages/IRAS/reviewResearch/userAdministration/manageUsers/EditUserProfilePage.ts
+++ b/src/pages/IRAS/reviewResearch/userAdministration/manageUsers/EditUserProfilePage.ts
@@ -27,11 +27,13 @@ export default class EditUserProfilePage {
   readonly review_body_dropdown: Locator;
   readonly country_label: Locator;
   readonly access_required_label: Locator;
+  private _title: string;
 
   //Initialize Page Objects
   constructor(page: Page) {
     this.page = page;
     this.editUserProfilePageTestData = editUserProfilePageTestData;
+    this._title = '';
 
     //Locators
     this.page_heading = this.page
@@ -143,5 +145,13 @@ export default class EditUserProfilePage {
       }
     }
     return checkedLabels;
+  }
+
+  async getUniqueTitle(): Promise<string> {
+    return this._title;
+  }
+
+  async setUniqueTitle(value: string): Promise<void> {
+    this._title = value;
   }
 }

--- a/src/steps/IRAS/reviewResearch/userAdministration/manageUsers/EditUserProfileSteps.ts
+++ b/src/steps/IRAS/reviewResearch/userAdministration/manageUsers/EditUserProfileSteps.ts
@@ -55,18 +55,15 @@ When(
         } else if (key == 'title_text') {
           const prefix = dataset.title_text;
           uniqueTitle = await generateUniqueValue('', prefix);
-          await editUserProfilePage.setUniqueTitle(uniqueTitle);
           const locator: Locator = editUserProfilePage[key];
           await locator.fill(uniqueTitle);
         } else if (key == 'job_title_text') {
           const prefix = dataset.job_title_text;
           uniqueJobTitle = await generateUniqueValue('', prefix);
-          await editUserProfilePage.setUniqueTitle(uniqueJobTitle);
           const locator: Locator = editUserProfilePage[key];
           await locator.fill(uniqueJobTitle);
         } else if (key == 'telephone_text') {
           uniqueTelephoneNumber = await generatePhoneNumber();
-          await editUserProfilePage.setUniqueTitle(uniqueTelephoneNumber);
           const locator: Locator = editUserProfilePage[key];
           await locator.fill(uniqueTelephoneNumber);
         } else {

--- a/src/steps/IRAS/reviewResearch/userAdministration/manageUsers/EditUserProfileSteps.ts
+++ b/src/steps/IRAS/reviewResearch/userAdministration/manageUsers/EditUserProfileSteps.ts
@@ -1,6 +1,6 @@
 import { createBdd } from 'playwright-bdd';
 import { test, expect } from '../../../../../hooks/CustomFixtures';
-import { generateUniqueEmail } from '../../../../../utils/UtilFunctions';
+import { generateUniqueEmail, generateUniqueValue, generatePhoneNumber } from '../../../../../utils/UtilFunctions';
 import { Locator } from 'playwright/test';
 
 const { Then, When } = createBdd(test);
@@ -33,6 +33,10 @@ When(
     let keyIndex = 1;
     let keyValue: any;
     let uniqueEmail: any;
+    let uniqueTitle: any;
+    let uniqueJobTitle: any;
+    let uniqueTelephoneNumber: any;
+
     if (fieldName.toLowerCase() == 'country' || fieldName.toLowerCase() == 'role') {
       const datasetNameClear: string = 'Edit_User_Profile_Page';
       const clearDataset = editUserProfilePage.editUserProfilePageTestData[datasetNameClear];
@@ -48,6 +52,23 @@ When(
           uniqueEmail = await generateUniqueEmail(dataset[key], prefix);
           const locator: Locator = editUserProfilePage[key];
           await locator.fill(uniqueEmail);
+        } else if (key == 'title_text') {
+          const prefix = dataset.title_text;
+          uniqueTitle = await generateUniqueValue('', prefix);
+          await editUserProfilePage.setUniqueTitle(uniqueTitle);
+          const locator: Locator = editUserProfilePage[key];
+          await locator.fill(uniqueTitle);
+        } else if (key == 'job_title_text') {
+          const prefix = dataset.job_title_text;
+          uniqueJobTitle = await generateUniqueValue('', prefix);
+          await editUserProfilePage.setUniqueTitle(uniqueJobTitle);
+          const locator: Locator = editUserProfilePage[key];
+          await locator.fill(uniqueJobTitle);
+        } else if (key == 'telephone_text') {
+          uniqueTelephoneNumber = await generatePhoneNumber();
+          await editUserProfilePage.setUniqueTitle(uniqueTelephoneNumber);
+          const locator: Locator = editUserProfilePage[key];
+          await locator.fill(uniqueTelephoneNumber);
         } else {
           await commonItemsPage.fillUIComponent(dataset, key, editUserProfilePage);
         }
@@ -56,7 +77,7 @@ When(
     }
     switch (fieldName.toLowerCase()) {
       case 'title':
-        await userProfilePage.setNewTitle(keyValue);
+        await userProfilePage.setNewTitle(uniqueTitle);
         break;
       case 'first_name':
         await userProfilePage.setNewFirstName(keyValue);
@@ -68,13 +89,13 @@ When(
         await userProfilePage.setNewEmail(uniqueEmail);
         break;
       case 'telephone':
-        await userProfilePage.setNewTelephone(keyValue);
+        await userProfilePage.setNewTelephone(uniqueTelephoneNumber);
         break;
       case 'organisation':
         await userProfilePage.setNewOrganisation(keyValue);
         break;
       case 'job_title':
-        await userProfilePage.setNewJobTitle(keyValue);
+        await userProfilePage.setNewJobTitle(uniqueJobTitle);
         break;
       case 'country':
         await userProfilePage.setNewCountries(keyValue);

--- a/src/utils/UtilFunctions.ts
+++ b/src/utils/UtilFunctions.ts
@@ -517,6 +517,16 @@ export async function generateUniqueValue(keyVal: string, prefix: string): Promi
   return `${domain}${prefix}${timestamp}`;
 }
 
+export async function generatePhoneNumber(): Promise<string> {
+  const prefix = '07';
+  const digitsNeeded = 9;
+  let number = '';
+  for (let i = 0; i < digitsNeeded; i++) {
+    number += Math.floor(Math.random() * 10).toString();
+  }
+  return prefix + number;
+}
+
 export async function removeUnwantedWhitespace(value: string): Promise<string> {
   return value.replaceAll(/\s+/g, ' ').trim();
 }


### PR DESCRIPTION
## What was the purpose of this ticket?

On regression automation run some scenarios fails in Edit user, if same data has been picked up for multiple scenarios, for the edit user scenarios, if update value is equal to the existing value then audit history event is not captured as expected (example - tile is “Master”  if we update it again with same value “Master”) , this issue identified specifically for the following fields ‘Title’, ‘Job title, and ‘Telephone number’, to resolve this issue we can edit these fields with unique value every time

## Jira Ref


[RSP-4041](https://nihr.atlassian.net/browse/RSP-4041)

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New Tests
- [X] Updating Tests
- [X] Fixing Tests
- [] Framework Improvements
- [] Documentation

## Solution

What work was completed to cover off the story?

- List out changes made to the repo

## Checklist

Put [X] inside the [] to make the box ticked

- [X] Your code builds clean without any warnings, i.e. no ESLint or SonarCube errors
- [X] You have run the Pipeline jobs against this branch successfully
- [X] Any new or updated tests add value, i.e. provide correct assurances, fail when expected and log errors appropriately
- [X] Tests have been tagged appropriately
- [X] No duplicate tests, steps or functions have been added
- [X] You are using the correct naming conventions
- [X] Added files have been placed correctly within the projects folder structure
- [X] There is no dead code e.g. no "TODO" comments left, no unused imports etc
- [] Any Framework updates have been explained and demonstrated to the team
