### PR TITLE
Advace Filters Retain and Clear Scenarios

### DIFF
--- a/tests/features/cross-compatible/stories/systemTests/reviewResearch/receiveAmendments/AdvancedFilterSearchModifications.feature
+++ b/tests/features/cross-compatible/stories/systemTests/reviewResearch/receiveAmendments/AdvancedFilterSearchModifications.feature
@@ -629,3 +629,28 @@ Feature: Approvals - Advanced Filter and Search combinations in the Search modif
                 Examples:
                         | Advanced_Filters     | Advanced_Filters_Labels      |
                         | Advanced_Filters_Nth | Advanced_Filters_Hint_Labels |
+
+        @rsp-4381 @ActiveFilterCleareWhenMoveToDifferentPage
+        Scenario Outline: verify that all active filters are automatically cleared when the user navigates away from the current page in search modification page 
+                And I click the 'Advanced_Filters' button on the 'Search_Modifications_Page'
+                And I capture the page screenshot
+                And I select advanced filters in the search modifications page using '<Advanced_Filters>'
+                And I capture the page screenshot
+                And I click the 'Apply_Filters' button on the 'Search_Modifications_Page'
+                And I capture the page screenshot
+                Then I sequentially navigate through each 'Search_Modifications_Page' by clicking on '<Navigation_Method>' from last page to verify pagination results, surrounding pages, and ellipses for skipped ranges
+                And I capture the page screenshot
+                Then 'I can see the selected filters are displayed under' active filters '<Advanced_Filters>' in the 'Search_Modifications_Page'
+                And I capture the page screenshot
+                When I click the 'Back' link on the 'Search_Modifications_Page'
+                Then I can see the approvals home page
+                And I click the 'Search' link on the 'Approvals_Page'
+                Then I can see the 'Search_Modifications_Page'
+                And all selected filters displayed under active Filters have been successfully removed
+                And I capture the page screenshot
+              
+                Examples:
+                        | Navigation_Method | Advanced_Filters             |
+                        | page number       | Advanced_Filters_Lead_Nation |
+                        | previous link     | Advanced_Filters_Lead_Nation |
+

--- a/tests/features/cross-compatible/stories/systemTests/reviewResearch/receiveAmendments/ModificationsReadyToAssign.feature
+++ b/tests/features/cross-compatible/stories/systemTests/reviewResearch/receiveAmendments/ModificationsReadyToAssign.feature
@@ -109,3 +109,37 @@ Feature: Modifications Tasklist page that displays modifications ready to be ass
             | Short_Project_Title   |
             | Date_Submitted        |
             | Days_Since_Submission |
+
+    @rsp-4381  @KNOWN-DEFECT-RSP-5045 @fail @ActiveFilterCleareWhenMoveToDifferentPage
+    Scenario Outline: verify that all active filters are automatically cleared when the user navigates away from the current page in modification tasklist page 
+        And I click the 'Advanced_Filters' button on the 'Modifications_Tasklist_Page'
+        And I 'can' see the advanced filters panel
+        And I open each of the modification tasklist filters
+        And I capture the page screenshot
+        When I fill the modifications tasklist search and filter options with 'Date_From_Multi'
+        And I capture the page screenshot
+        And I click the 'Apply_Filters' button on the 'Modifications_Tasklist_Page'
+        And I 'can' see active filters displayed
+        And I capture the page screenshot
+        Then I can see the '<Validation_Text>' ui labels on the modifications ready to assign page
+        When I am on the 'first' page and it should be visually highlighted to indicate the active page the user is on
+        And I capture the page screenshot
+        And the 'Next' button will be 'available' to the user
+        And the 'Previous' button will be 'not available' to the user
+        And I capture the page screenshot
+        Then I sequentially navigate through each 'Modifications_Tasklist_Page' by clicking on '<Navigation_Method>' from last page to verify pagination results, surrounding pages, and ellipses for skipped ranges
+        And I capture the page screenshot
+        And I 'can' see active filters displayed
+        And I capture the page screenshot
+        When I click the 'Back' link on the 'Modifications_Tasklist_Page'
+        Then I can see the approvals home page
+        Given I have navigated to the 'Modifications_Tasklist_Page'
+        And I capture the page screenshot
+        Then I can see the 'Modifications_Tasklist_Page'
+        And I 'cannot' see the advanced filters panel
+        And I capture the page screenshot
+      
+        Examples:
+            | Validation_Text | Navigation_Method       |
+            | Label_Texts     | clicking on page number |
+            | Label_Texts     | clicking on next link   |

--- a/tests/features/cross-compatible/stories/systemTests/reviewResearch/userAdministration/manageReviewBodies/AdvancedFilterReviewBody.feature
+++ b/tests/features/cross-compatible/stories/systemTests/reviewResearch/userAdministration/manageReviewBodies/AdvancedFilterReviewBody.feature
@@ -210,3 +210,81 @@ Feature: Review Bodies - Advanced Filter and Search combinations in the Manage r
     Examples:
       | Advanced_Filters                     |
       | Advanced_Filter_All_Countries_Active |
+
+  @rsp-4381 @ActiveFilterCleareWhenMoveToDifferentPage 
+  Scenario: verify that all active filters are automatically cleared when the user navigates away from the current page in mange review body page
+    And I click the 'Advanced_Filters' button on the 'Manage_Review_Bodies_Page'
+    And I select advanced filters in the manage review bodies page using '<Advanced_Filters>'
+    And I capture the page screenshot
+    And I click the 'Apply_filters' button on the 'Manage_Review_Bodies_Page'
+    Then 'I can see the selected filters are displayed under' active filters '<Advanced_Filters>' in the 'Manage_Review_Bodies_Page'
+    And I capture the page screenshot
+    And I click the 'Back' link on the 'Manage_Review_Bodies_Page'
+    And I capture the page screenshot
+    Then I can see the 'System_Administration_Page'
+    And I click the 'Manage_Review_Bodies' link on the 'System_Administration_Page'
+    Then I can see the 'Manage_Review_Bodies_Page'
+    Then I can see the selected filters '<Advanced_Filters>' are removed from active filters for manage review bodies page
+    And I capture the page screenshot
+
+    Examples:
+      | Advanced_Filters                     |
+      | Advanced_Filter_All_Countries_Active |
+
+    @rsp-4381 @ActiveFilterRemainAppliedAfterCreateNewReviewBody 
+    Scenario Outline: Verify that the active filter remains applied after creating a new review body with valid data
+        And I click the 'Advanced_Filters' button on the 'Manage_Review_Bodies_Page'
+        And I select advanced filters in the manage review bodies page using '<Advanced_Filters>'
+        And I capture the page screenshot
+        And I click the 'Apply_filters' button on the 'Manage_Review_Bodies_Page'
+        Then 'I can see the selected filters are displayed under' active filters '<Advanced_Filters>' in the 'Manage_Review_Bodies_Page'
+        And I capture the page screenshot
+        And I click the 'Add_New_Review_Body_Record' link on the 'Manage_Review_Bodies_Page'
+        Then I can see the 'Create_Review_Body_Page'
+        When I fill the new review body page using '<Add_Review_Body>'
+        And I capture the page screenshot
+        And I click the 'Continue' button on the 'Create_Review_Body_Page'
+        Then I can see the check and create review body page for '<Add_Review_Body>'
+        And I capture the page screenshot
+        When I click the 'Create_Profile' button on the 'Check_Create_Review_Body_Page'
+        Then I can see the create Review body confirmation page for '<Add_Review_Body>'
+        And I capture the page screenshot
+        When I have navigated to the 'Manage_Review_Bodies_Page'
+        Then I can see the 'Manage_Review_Bodies_Page'
+        Then 'I can see the selected filters are displayed under' active filters '<Advanced_Filters>' in the 'Manage_Review_Bodies_Page'
+        And I capture the page screenshot
+
+        Examples:
+            | Add_Review_Body           | Status  | Advanced_Filters                     |
+            | Valid_Data_In_All_Fields  | enabled | Advanced_Filter_All_Countries_Active |
+
+    @rsp-4381 @ActiveFilterRemainAppliedAfterEditTheReviewBody 
+    Scenario Outline: Verify that the active filter remains applied after edit the review body and save their changes
+        And I click the 'Advanced_Filters' button on the 'Manage_Review_Bodies_Page'
+        And I select advanced filters in the manage review bodies page using '<Advanced_Filters>'
+        And I capture the page screenshot
+        And I click the 'Apply_filters' button on the 'Manage_Review_Bodies_Page'
+        Then 'I can see the selected filters are displayed under' active filters '<Advanced_Filters>' in the 'Manage_Review_Bodies_Page'
+        And I capture the page screenshot
+        When I enter 'QA Automation' into the search field
+        And I click the 'Search' button on the 'Manage_Review_Bodies_Page'
+        And I select a 'QA Automation' review Body to View and Edit which is 'Enabled'
+        And I can see the review body profile page
+        And I capture the page screenshot
+        And I click the change link against '<Field_Name>' on the review body profile page
+        And I can see the edit review body page
+        And I capture the page screenshot
+        When I fill the edit review body page using '<Edit_Review_Body>'
+        And I capture the page screenshot
+        And I click the 'Save' button on the 'Edit_Review_Body_Page'
+        Then I now see the review body profile page with the updated '<Edit_Review_Body>'
+        And I capture the page screenshot
+        When I have navigated to the 'Manage_Review_Bodies_Page'
+        Then I can see the 'Manage_Review_Bodies_Page'
+        And I capture the page screenshot
+        Then 'I can see the selected filters are displayed under' active filters '<Advanced_Filters>' in the 'Manage_Review_Bodies_Page'
+        And I capture the page screenshot
+
+        Examples:
+            | Edit_Review_Body         | Field_Name        | Advanced_Filters                     |
+            | Valid_Data_In_All_Fields | Organisation_Name | Advanced_Filter_All_Countries_Active |

--- a/tests/features/cross-compatible/stories/systemTests/reviewResearch/userAdministration/manageUsers/AdvancedFilterManageUser.feature
+++ b/tests/features/cross-compatible/stories/systemTests/reviewResearch/userAdministration/manageUsers/AdvancedFilterManageUser.feature
@@ -277,3 +277,86 @@ Feature: users - Advanced Filter and Search combinations in the Manage users pag
             | Advanced_Filter_Country_No_Review_Body_No_Role_Workflow_Coordinator     |
             | Advanced_Filter_Country_No_Review_Body_All_Role_All                     |
             | Advanced_Filter_Country_No_Review_Body_No_Role_No_Status_Active_To_Date |
+
+    @rsp-4381 @ActiveFilterCleareWhenMoveToDifferentPage 
+    Scenario Outline: verify that all active filters are automatically cleared when the user navigates away from the current page in mange user page
+        And I click the 'Advanced_Filters' button on the 'Manage_Users_Page'
+        And I select advanced filters in the manage users page using '<Advanced_Filters>'
+        And I capture the page screenshot
+        And I click the 'Apply_Filters' button on the 'Manage_Users_Page'
+        And I capture the page screenshot
+        Then 'I can see the selected filters are displayed under' active filters '<Advanced_Filters>' in the 'Manage_Users_Page'
+        And I capture the page screenshot
+        Then I sequentially navigate through each 'Manage_Users_Page' by clicking on '<Navigation_Method>' from last page to verify pagination results, surrounding pages, and ellipses for skipped ranges
+        And I capture the page screenshot
+        Then 'I can see the selected filters are displayed under' active filters '<Advanced_Filters>' in the 'Manage_Users_Page'
+        And I capture the page screenshot
+        When I click the 'Back' link on the 'Manage_Users_Page'
+        Then I can see the 'System_Administration_Page'
+        When I click the 'Manage_Users' link on the 'System_Administration_Page'
+        Then I can see the 'Manage_Users_Page'
+        And all selected filters displayed under active Filters have been successfully removed
+        And I capture the page screenshot
+      
+        Examples:
+            | Navigation_Method        | Advanced_Filters     |
+            | page number              | Advanced_Filter_Nine |
+
+    @rsp-4381 @ActiveFilterRemainAppliedAfterCreateNewUserProfile 
+    Scenario Outline: Verify that the active filter remains applied after creating a new user profile with valid data
+        And I click the 'Advanced_Filters' button on the 'Manage_Users_Page'
+        And I select advanced filters in the manage users page using '<Advanced_Filters>'
+        And I capture the page screenshot
+        And I click the 'Apply_Filters' button on the 'Manage_Users_Page'
+        And I capture the page screenshot
+        Then 'I can see the selected filters are displayed under' active filters '<Advanced_Filters>' in the 'Manage_Users_Page'
+        And I capture the page screenshot
+        When I click the 'Add_New_User_Profile_Record' link on the 'Manage_Users_Page'
+        And I capture the page screenshot
+        When I fill the new user profile page using '<Add_User_Profile>'
+        And I capture the page screenshot
+        And I click the 'Continue' button on the 'Create_User_Profile_Page'
+        Then I can see the check and create user profile page
+        And I capture the page screenshot
+        Then I can see previously filled values in the new user profile page for '<Add_User_Profile>' displayed on the check and create user profile page
+        And I click the 'Create_Profile' button on the 'Check_Create_User_Profile_Page'
+        Then I can see the create user profile confirmation page for '<Add_User_Profile>'
+        And I capture the page screenshot
+        When I click the 'Back_To_Manage_Users' link on the 'Create_User_Profile_Confirmation_Page'
+        Then I can see the 'Manage_Users_Page'
+        And I capture the page screenshot
+        Then 'I can see the selected filters are displayed under' active filters '<Advanced_Filters>' in the 'Manage_Users_Page'
+        And I capture the page screenshot
+   
+        Examples:
+            | Add_User_Profile                                      | Validation_Text_Manage_Users_List | Status_Enabled | Advanced_Filters     |
+            |  Valid_Data_In_All_Fields_Role_System_Administrator   | Label_Texts_Manage_Users_List     | Enabled        | Advanced_Filter_Nine | 
+    
+    @rsp-4381 @ActiveFilterRemainAppliedAfterEditTheManageUser
+    Scenario Outline: Verify that the active filter remains applied after edit the manage user and save their changes
+        And I click the 'Advanced_Filters' button on the 'Manage_Users_Page'
+        And I select advanced filters in the manage users page using '<Advanced_Filters>'
+        And I capture the page screenshot
+        And I click the 'Apply_Filters' button on the 'Manage_Users_Page'
+        And I capture the page screenshot
+        Then 'I can see the selected filters are displayed under' active filters '<Advanced_Filters>' in the 'Manage_Users_Page'
+        And I capture the page screenshot
+        And I select a 'QA Automation' User to View and Edit which is 'active'
+        And I can see the user profile page
+        And I capture the page screenshot
+        When I click the change link against 'Title' on the user profile page
+        Then I can see the edit user profile page
+        And I capture the page screenshot
+        When I click the 'Back' link on the 'Edit_User_Profile_Page'
+        Then I can see the user profile page
+        And I capture the page screenshot
+        When I click the 'Back' link on the 'User_Profile_Page'
+        Then I can see the 'Manage_Users_Page'
+        And I capture the page screenshot
+        And I capture the page screenshot
+        Then 'I can see the selected filters are displayed under' active filters '<Advanced_Filters>' in the 'Manage_Users_Page'
+        And I capture the page screenshot
+      
+        Examples:
+            | Advanced_Filters     |
+            | Advanced_Filter_Nine |


### PR DESCRIPTION
## What was the purpose of this ticket?

As a user who has access to the system,
I want my selected filters to stick when I switch between pages and come back,
So that I don’t have to reapply them.

## Jira Ref

[RSP-4381](https://nihr.atlassian.net/browse/RSP-4381)

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New Tests
- [X] Updating Tests
- [] Fixing Tests
- [] Framework Improvements
- [] Documentation

## Solution

What work was completed to cover off the story?

- Retained the Advanced Filter State During Page Navigation.
- Advanced Filters Should Be Cleared After updating different page 

## Checklist

Put [X] inside the [] to make the box ticked

- [X] Your code builds clean without any warnings, i.e. no ESLint or SonarCube errors
- [X] You have run the Pipeline jobs against this branch successfully
- [X] Any new or updated tests add value, i.e. provide correct assurances, fail when expected and log errors appropriately
- [X] Tests have been tagged appropriately
- [X] No duplicate tests, steps or functions have been added
- [X] You are using the correct naming conventions
- [X] Added files have been placed correctly within the projects folder structure
- [X] There is no dead code e.g. no "TODO" comments left, no unused imports etc
- [X] Any Framework updates have been explained and demonstrated to the team
